### PR TITLE
Update grammar and snippets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,37 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-    "version": "0.1.0",
-    "configurations": [
-        {
-            "name": "Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/**/*.js" ],
-            "preLaunchTask": "npm: watch"
-        },
-        {
-            "name": "Extension Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-            "preLaunchTask": "npm: watch"
-        }
-    ]
+  "version": "0.1.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}",
+        "--extensionTestsPath=${workspaceRoot}/out/test"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/out/test/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    }
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,20 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "type": "npm",
-            "script": "watch",
-            "problemMatcher": "$tsc-watch",
-            "isBackground": true,
-            "presentation": {
-                "reveal": "never"
-            },
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -57,18 +57,26 @@
       {
         "language": "wasm",
         "scopeName": "source.wat",
-        "path": "./syntaxes/webassembly.tmLanguage.json"
+        "path": "./syntaxes/wat.json"
       },
       {
         "language": "wat",
         "scopeName": "source.wat",
-        "path": "./syntaxes/webassembly.tmLanguage.json"
+        "path": "./syntaxes/wat.json"
       }
     ],
     "snippets": [
       {
         "language": "wat",
-        "path": "./snippets/wat.snippets.json"
+        "path": "./snippets/types.json"
+      },
+      {
+        "language": "wat",
+        "path": "./snippets/instructions.json"
+      },
+      {
+        "language": "wat",
+        "path": "./snippets/sections.json"
       }
     ],
     "commands": [

--- a/package.json
+++ b/package.json
@@ -1,158 +1,158 @@
 {
-    "name": "vscode-wasm",
-    "displayName": "WebAssembly",
-    "description": "WebAssembly Toolkit for VSCode",
-    "version": "1.2.1",
-    "publisher": "dtsvet",
-    "license": "MIT",
-    "icon": "images/vscode-wasm-logo.png",
-    "engines": {
-        "vscode": "^1.18.0"
-    },
-    "bugs": {
-        "url": "https://github.com/reklatsmasters/vscode-wasm/issues"
-    },
-    "homepage": "https://github.com/reklatsmasters/vscode-wasm",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/reklatsmasters/vscode-wasm.git"
-    },
-    "categories": [
-        "Programming Languages",
-        "Other"
+  "name": "vscode-wasm",
+  "displayName": "WebAssembly",
+  "description": "WebAssembly Toolkit for VSCode",
+  "version": "1.2.1",
+  "publisher": "dtsvet",
+  "license": "MIT",
+  "icon": "images/vscode-wasm-logo.png",
+  "engines": {
+    "vscode": "^1.18.0"
+  },
+  "bugs": {
+    "url": "https://github.com/reklatsmasters/vscode-wasm/issues"
+  },
+  "homepage": "https://github.com/reklatsmasters/vscode-wasm",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reklatsmasters/vscode-wasm.git"
+  },
+  "categories": [
+    "Programming Languages",
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:wasm",
+    "onCommand:wasm.wasm2wat",
+    "onCommand:wasm.save2wat",
+    "onCommand:wasm.save2wasm"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "wasm",
+        "extensions": [
+          ".wasm"
+        ],
+        "aliases": [
+          "WebAssembly Binary",
+          "WebAssembly"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "wat",
+        "extensions": [
+          ".wat",
+          ".wast"
+        ],
+        "aliases": [
+          "WebAssembly Text"
+        ],
+        "configuration": "./language-configuration.json"
+      }
     ],
-    "activationEvents": [
-        "onLanguage:wasm",
-        "onCommand:wasm.wasm2wat",
-        "onCommand:wasm.save2wat",
-        "onCommand:wasm.save2wasm"
+    "grammars": [
+      {
+        "language": "wasm",
+        "scopeName": "source.wat",
+        "path": "./syntaxes/webassembly.tmLanguage.json"
+      },
+      {
+        "language": "wat",
+        "scopeName": "source.wat",
+        "path": "./syntaxes/webassembly.tmLanguage.json"
+      }
     ],
-    "main": "./out/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "wasm",
-                "extensions": [
-                    ".wasm"
-                ],
-                "aliases": [
-                    "WebAssembly Binary",
-                    "WebAssembly"
-                ],
-                "configuration": "./language-configuration.json"
-            },
-            {
-                "id": "wat",
-                "extensions": [
-                    ".wat",
-                    ".wast"
-                ],
-                "aliases": [
-                    "WebAssembly Text"
-                ],
-                "configuration": "./language-configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "wasm",
-                "scopeName": "source.wasm",
-                "path": "./syntaxes/webassembly.tmLanguage.json"
-            },
-            {
-                "language": "wat",
-                "scopeName": "source.wasm",
-                "path": "./syntaxes/webassembly.tmLanguage.json"
-            }
-        ],
-        "snippets": [
-			{
-				"language": "wat",
-				"path": "./snippets/wat.snippets.json"
-			}
-		],
-        "commands": [
-            {
-                "command": "wasm.wasm2wat",
-                "title": "Show WebAssembly",
-                "category": "wasm"
-            },
-            {
-                "command": "wasm.save2wat",
-                "title": "Save as WebAssembly text file",
-                "category": "wasm"
-            },
-            {
-                "command": "wasm.save2wasm",
-                "title": "Save as WebAssembly binary file",
-                "category": "wasm"
-            }
-        ],
-        "menus": {
-            "explorer/context": [
-                {
-                    "command": "wasm.wasm2wat",
-                    "when": "resourceLangId == wasm",
-                    "group": "wasm"
-                },
-                {
-                    "command": "wasm.save2wat",
-                    "when": "resourceLangId == wasm",
-                    "group": "wasm"
-                },
-                {
-                    "command": "wasm.save2wasm",
-                    "when": "resourceLangId == wat",
-                    "group": "wasm"
-                }
-            ],
-            "editor/context": [
-                {
-                    "command": "wasm.save2wat",
-                    "when": "resourceLangId == wasm",
-                    "group": "wasm"
-                },
-                {
-                    "command": "wasm.save2wasm",
-                    "when": "resourceLangId == wat",
-                    "group": "wasm"
-                }
-            ],
-            "editor/title/context": [
-                {
-                    "command": "wasm.save2wat",
-                    "when": "resourceLangId == wasm",
-                    "group": "wasm"
-                },
-                {
-                    "command": "wasm.save2wasm",
-                    "when": "resourceLangId == wat",
-                    "group": "wasm"
-                }
-            ]
+    "snippets": [
+      {
+        "language": "wat",
+        "path": "./snippets/wat.snippets.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "wasm.wasm2wat",
+        "title": "Show WebAssembly",
+        "category": "wasm"
+      },
+      {
+        "command": "wasm.save2wat",
+        "title": "Save as WebAssembly text file",
+        "category": "wasm"
+      },
+      {
+        "command": "wasm.save2wasm",
+        "title": "Save as WebAssembly binary file",
+        "category": "wasm"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "wasm.wasm2wat",
+          "when": "resourceLangId == wasm",
+          "group": "wasm"
+        },
+        {
+          "command": "wasm.save2wat",
+          "when": "resourceLangId == wasm",
+          "group": "wasm"
+        },
+        {
+          "command": "wasm.save2wasm",
+          "when": "resourceLangId == wat",
+          "group": "wasm"
         }
-    },
-    "keywords": [
-        "wasm",
-        "wast",
-        "webassembly",
-        "asm",
-        "web assembly"
-    ],
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.48",
-        "@types/node": "^7.0.61",
-        "typescript": "^2.9.2",
-        "vscode": "^1.1.36"
-    },
-    "dependencies": {
-        "wabt": "^1.0.11"
+      ],
+      "editor/context": [
+        {
+          "command": "wasm.save2wat",
+          "when": "resourceLangId == wasm",
+          "group": "wasm"
+        },
+        {
+          "command": "wasm.save2wasm",
+          "when": "resourceLangId == wat",
+          "group": "wasm"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "wasm.save2wat",
+          "when": "resourceLangId == wasm",
+          "group": "wasm"
+        },
+        {
+          "command": "wasm.save2wasm",
+          "when": "resourceLangId == wat",
+          "group": "wasm"
+        }
+      ]
     }
+  },
+  "keywords": [
+    "wasm",
+    "wast",
+    "webassembly",
+    "asm",
+    "web assembly"
+  ],
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.48",
+    "@types/node": "^7.0.61",
+    "typescript": "^2.9.2",
+    "vscode": "^1.1.36"
+  },
+  "dependencies": {
+    "wabt": "^1.0.11"
+  }
 }

--- a/snippets/instructions.json
+++ b/snippets/instructions.json
@@ -1,24 +1,4 @@
 {
-  "module": {
-    "body": "module\n\t${1:}\n",
-    "prefix": "module"
-  },
-  "export": {
-    "body": "export ${1:\"name\"} (func ${2:$$name})",
-    "prefix": "export"
-  },
-  "func-i32-0": {
-    "body": "func ${1:$$name} (result ${2:i32})\n\t${3:}\n",
-    "prefix": "func"
-  },
-  "func-i32-1": {
-    "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (result ${4:i32})\n\t${5:}\n",
-    "prefix": "func"
-  },
-  "func-i32-2": {
-    "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (param ${4:$$rhs} ${5:i32}) (result ${6:i32})\n\t${7:}\n",
-    "prefix": "func"
-  },
   "i32.trunc_sat_f32_s": {
     "body": "i32.trunc_sat_f32_s",
     "prefix": "i32.trunc_sat_f32_s"
@@ -86,10 +66,6 @@
   "memory.drop": {
     "body": "memory.drop",
     "prefix": "memory.drop"
-  },
-  "v128": {
-    "body": "v128",
-    "prefix": "v128"
   },
   "v128.const": {
     "body": "v128.const ",
@@ -1051,18 +1027,6 @@
     "body": "atomic.fence",
     "prefix": "atomic.fence"
   },
-  "anyref": {
-    "body": "anyref",
-    "prefix": "anyref"
-  },
-  "funcref": {
-    "body": "funcref",
-    "prefix": "funcref"
-  },
-  "nullref": {
-    "body": "nullref",
-    "prefix": "nullref"
-  },
   "ref.null": {
     "body": "ref.null",
     "prefix": "ref.null"
@@ -1106,10 +1070,6 @@
   "return_call_indirect": {
     "body": "return_call_indirect ",
     "prefix": "return_call_indirect"
-  },
-  "exnref": {
-    "body": "exnref",
-    "prefix": "exnref"
   },
   "try": {
     "body": "try",
@@ -1194,22 +1154,6 @@
   "exnref.pop": {
     "body": "exnref.pop",
     "prefix": "exnref.pop"
-  },
-  "i32": {
-    "body": "i32",
-    "prefix": "i32"
-  },
-  "i64": {
-    "body": "i64",
-    "prefix": "i64"
-  },
-  "f32": {
-    "body": "f32",
-    "prefix": "f32"
-  },
-  "f64": {
-    "body": "f64",
-    "prefix": "f64"
   },
   "i32.load": {
     "body": "i32.load",

--- a/snippets/sections.json
+++ b/snippets/sections.json
@@ -1,0 +1,26 @@
+{
+  "module": {
+    "body": "module\n\t${1:}\n",
+    "prefix": "module"
+  },
+  "export": {
+    "body": "export ${1:\"externalName\"} (func ${2:\\$name})",
+    "prefix": "export"
+  },
+  "import": {
+    "body": "import ${1:\"externalModuleName\"} ${2:\"externalName\"} (func ${3:\\$name} (param ${4:}) (result ${5:}))",
+    "prefix": "import"
+  },
+  "func-i32-0": {
+    "body": "func ${1:\\$name} (result ${2:i32})\n\t${3:}\n",
+    "prefix": "func"
+  },
+  "func-i32-1": {
+    "body": "func ${1:\\$name} (param ${2:\\$a} ${3:i32}) (result ${4:i32})\n\t${5:}\n",
+    "prefix": "func"
+  },
+  "func-i32-2": {
+    "body": "func ${1:\\$name} (param ${2:\\$a} ${3:i32}) (param ${4:\\$b} ${5:i32}) (result ${6:i32})\n\t${7:}\n",
+    "prefix": "func"
+  }
+}

--- a/snippets/types.json
+++ b/snippets/types.json
@@ -1,0 +1,38 @@
+{
+  "i32": {
+    "body": "i32",
+    "prefix": "i32"
+  },
+  "i64": {
+    "body": "i64",
+    "prefix": "i64"
+  },
+  "f32": {
+    "body": "f32",
+    "prefix": "f32"
+  },
+  "f64": {
+    "body": "f64",
+    "prefix": "f64"
+  },
+  "v128": {
+    "body": "v128",
+    "prefix": "v128"
+  },
+  "anyref": {
+    "body": "anyref",
+    "prefix": "anyref"
+  },
+  "funcref": {
+    "body": "funcref",
+    "prefix": "funcref"
+  },
+  "nullref": {
+    "body": "nullref",
+    "prefix": "nullref"
+  },
+  "exnref": {
+    "body": "exnref",
+    "prefix": "exnref"
+  }
+}

--- a/snippets/wat.snippets.json
+++ b/snippets/wat.snippets.json
@@ -1,710 +1,1902 @@
 {
-    "module": {
-        "body": "module\n\t${1:}\n",
-        "prefix": "module"
-    },
-    "export": {
-        "body": "export ${1:\"name\"} (func ${2:$$name})",
-        "prefix": "export"
-    },
-    "memory.size": {
-        "body": "memory.size",
-        "prefix": "memory.size"
-    },
-    "memory.grow": {
-        "body": "memory.grow",
-        "prefix": "memory.grow"
-    },
-    "select": {
-        "body": "select",
-        "prefix": "select"
-    },
-    "drop": {
-        "body": "drop",
-        "prefix": "drop"
-    },
-    "return": {
-        "body": "return",
-        "prefix": "return"
-    },
-    "end": {
-        "body": "end",
-        "prefix": "end"
-    },
-    "unreachable": {
-        "body": "unreachable",
-        "prefix": "unreachable"
-    },
-    "nop": {
-        "body": "nop",
-        "prefix": "nop"
-    },
-    "block": {
-        "body": "block",
-        "prefix": "block"
-    },
-    "loop": {
-        "body": "loop",
-        "prefix": "loop"
-    },
-    "if": {
-        "body": "if",
-        "prefix": "if"
-    },
-    "else": {
-        "body": "else",
-        "prefix": "else"
-    },
-    "call": {
-        "body": "call ${1:x}",
-        "prefix": "call"
-    },
-    "call_indirect": {
-        "body": "call_indirect ${1:x}",
-        "prefix": "call_indirect"
-    },
-    "br": {
-        "body": "br ${1:l}",
-        "prefix": "br"
-    },
-    "br_if": {
-        "body": "br_if ${1:l}",
-        "prefix": "br_if"
-    },
-    "br_table": {
-        "body": "br_table ${1:l}",
-        "prefix": "br_table"
-    },
-    "local.get": {
-        "body": "local.get ${1:x}",
-        "prefix": "local.get"
-    },
-    "local.set": {
-        "body": "local.set ${1:x}",
-        "prefix": "local.set1"
-    },
-    "local.tee": {
-        "body": "local.tee ${1:x}",
-        "prefix": "local.tee"
-    },
-    "global.get": {
-        "body": "global.get ${1:x}",
-        "prefix": "global.get"
-    },
-    "global.set": {
-        "body": "global.set ${1:x}",
-        "prefix": "global.set"
-    },
-    "func-i32-0": {
-        "body": "func ${1:$$name} (result ${2:i32})\n\t${3:}\n",
-        "prefix": "func"
-    },
-    "func-i32-1": {
-        "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (result ${4:i32})\n\t${5:}\n",
-        "prefix": "func"
-    },
-    "func-i32-2": {
-        "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (param ${4:$$rhs} ${5:i32}) (result ${6:i32})\n\t${7:}\n",
-        "prefix": "func"
-    },
-    "i32.load": {
-        "body": "i32.load",
-        "prefix": "i32.load"
-    },
-    "i32.load8_s": {
-        "body": "i32.load8_s",
-        "prefix": "i32.load8_s"
-    },
-    "i32.load8_u": {
-        "body": "i32.load8_u",
-        "prefix": "i32.load8_u"
-    },
-    "i32.load16_s": {
-        "body": "i32.load16_s",
-        "prefix": "i32.load16_s"
-    },
-    "i32.load16_u": {
-        "body": "i32.load16_u",
-        "prefix": "i32.load16_u"
-    },
-    "i32.store": {
-        "body": "i32.store",
-        "prefix": "i32.store"
-    },
-    "i32.store8": {
-        "body": "i32.store8",
-        "prefix": "i32.store8"
-    },
-    "i32.store16": {
-        "body": "i32.store16",
-        "prefix": "i32.store16"
-    },
-    "i32.const": {
-        "body": "i32.const ${1:i32}",
-        "prefix": "i32.const"
-    },
-    "i32.eqz": {
-        "body": "i32.eqz",
-        "prefix": "i32.eqz"
-    },
-    "i32.eq": {
-        "body": "i32.eq",
-        "prefix": "i32.eq"
-    },
-    "i32.ne": {
-        "body": "i32.ne",
-        "prefix": "i32.ne"
-    },
-    "i32.lt_s": {
-        "body": "i32.lt_s",
-        "prefix": "i32.lt_s"
-    },
-    "i32.lt_u": {
-        "body": "i32.lt_u",
-        "prefix": "i32.lt_u"
-    },
-    "i32.gt_s": {
-        "body": "i32.gt_s",
-        "prefix": "i32.gt_s"
-    },
-    "i32.gt_u": {
-        "body": "i32.gt_u",
-        "prefix": "i32.gt_u"
-    },
-    "i32.le_s": {
-        "body": "i32.le_s",
-        "prefix": "i32.le_s"
-    },
-    "i32.le_u": {
-        "body": "i32.le_u",
-        "prefix": "i32.le_u"
-    },
-    "i32.ge_s": {
-        "body": "i32.ge_s",
-        "prefix": "i32.ge_s"
-    },
-    "i32.ge_u": {
-        "body": "i32.ge_u",
-        "prefix": "i32.ge_u"
-    },
-    "i32.clz": {
-        "body": "i32.clz",
-        "prefix": "i32.clz"
-    },
-    "i32.ctz": {
-        "body": "i32.ctz",
-        "prefix": "i32.ctz"
-    },
-    "i32.popcnt": {
-        "body": "i32.popcnt",
-        "prefix": "i32.popcnt"
-    },
-    "i32.add": {
-        "body": "i32.add",
-        "prefix": "i32.add"
-    },
-    "i32.sub": {
-        "body": "i32.sub",
-        "prefix": "i32.sub"
-    },
-    "i32.mul": {
-        "body": "i32.mul",
-        "prefix": "i32.mul"
-    },
-    "i32.div_s": {
-        "body": "i32.div_s",
-        "prefix": "i32.div_s"
-    },
-    "i32.div_u": {
-        "body": "i32.div_u",
-        "prefix": "i32.div_u"
-    },
-    "i32.rem_s": {
-        "body": "i32.rem_s",
-        "prefix": "i32.rem_s"
-    },
-    "i32.rem_u": {
-        "body": "i32.rem_u",
-        "prefix": "i32.rem_u"
-    },
-    "i32.and": {
-        "body": "i32.and",
-        "prefix": "i32.and"
-    },
-    "i32.or": {
-        "body": "i32.or",
-        "prefix": "i32.or"
-    },
-    "i32.xor": {
-        "body": "i32.xor",
-        "prefix": "i32.xor"
-    },
-    "i32.shl": {
-        "body": "i32.shl",
-        "prefix": "i32.shl"
-    },
-    "i32.shr_s": {
-        "body": "i32.shr_s",
-        "prefix": "i32.shr_s"
-    },
-    "i32.shr_u": {
-        "body": "i32.shr_u",
-        "prefix": "i32.shr_u"
-    },
-    "i32.rotl": {
-        "body": "i32.rotl",
-        "prefix": "i32.rotl"
-    },
-    "i32.rotr": {
-        "body": "i32.rotr",
-        "prefix": "i32.rotr"
-    },
-    "i32.wrap_i64": {
-        "body": "i32.wrap_i64",
-        "prefix": "i32.wrap_i64"
-    },
-    "i32.trunc_f32_s": {
-        "body": "i32.trunc_f32_s",
-        "prefix": "i32.trunc_f32_s"
-    },
-    "i32.trunc_f32_u": {
-        "body": "i32.trunc_f32_u",
-        "prefix": "i32.trunc_f32_u"
-    },
-    "i32.trunc_f64_s": {
-        "body": "i32.trunc_f64_s",
-        "prefix": "i32.trunc_f64_s"
-    },
-    "i32.trunc_f64_u": {
-        "body": "i32.trunc_f64_u",
-        "prefix": "i32.trunc_f64_u"
-    },
-    "i32.reinterpret_f32": {
-        "body": "i32.reinterpret_f32",
-        "prefix": "i32.reinterpret_f32"
-    },
-    "i64.load8": {
-        "body": "i64.load8",
-        "prefix": "i64.load8"
-    },
-    "i64.load8_s": {
-        "body": "i64.load8_s",
-        "prefix": "i64.load8_s"
-    },
-    "i64.load8_u": {
-        "body": "i64.load8_u",
-        "prefix": "i64.load8_u"
-    },
-    "i64.load16_s": {
-        "body": "i64.load16_s",
-        "prefix": "i64.load16_s"
-    },
-    "i64.load16_u": {
-        "body": "i64.load16_u",
-        "prefix": "i64.load16_u"
-    },
-    "i64.load32_s": {
-        "body": "i64.load32_s",
-        "prefix": "i64.load32_s"
-    },
-    "i64.load32_u": {
-        "body": "i64.load32_u",
-        "prefix": "i64.load32_u"
-    },
-    "i64.store": {
-        "body": "i64.store",
-        "prefix": "i64.store"
-    },
-    "i64.store8": {
-        "body": "i64.store8",
-        "prefix": "i64.store8"
-    },
-    "i64.store16": {
-        "body": "i64.store16",
-        "prefix": "i64.store16"
-    },
-    "i64.store32": {
-        "body": "i64.store32",
-        "prefix": "i64.store32"
-    },
-    "i64.const": {
-        "body": "i64.const ${1:i64}",
-        "prefix": "i64.const"
-    },
-    "i64.eqz": {
-        "body": "i64.eqz",
-        "prefix": "i64.eqz"
-    },
-    "i64.eq": {
-        "body": "i64.eq",
-        "prefix": "i64.eq"
-    },
-    "i64.ne": {
-        "body": "i64.ne",
-        "prefix": "i64.ne"
-    },
-    "i64.lt_s": {
-        "body": "i64.lt_s",
-        "prefix": "i64.lt_s"
-    },
-    "i64.lt_u": {
-        "body": "i64.lt_u",
-        "prefix": "i64.lt_u"
-    },
-    "i64.gt_s": {
-        "body": "i64.gt_s",
-        "prefix": "i64.gt_s"
-    },
-    "i64.gt_u": {
-        "body": "i64.gt_u",
-        "prefix": "i64.gt_u"
-    },
-    "i64.le_s": {
-        "body": "i64.le_s",
-        "prefix": "i64.le_s"
-    },
-    "i64.le_u": {
-        "body": "i64.le_u",
-        "prefix": "i64.le_u"
-    },
-    "i64.ge_s": {
-        "body": "i64.ge_s",
-        "prefix": "i64.ge_s"
-    },
-    "i64.ge_u": {
-        "body": "i64.ge_u",
-        "prefix": "i64.ge_u"
-    },
-    "i64.clz": {
-        "body": "i64.clz",
-        "prefix": "i64.clz"
-    },
-    "i64.ctz": {
-        "body": "i64.ctz",
-        "prefix": "i64.ctz"
-    },
-    "i64.popcnt": {
-        "body": "i64.popcnt",
-        "prefix": "i64.popcnt"
-    },
-    "i64.add": {
-        "body": "i64.add",
-        "prefix": "i64.add"
-    },
-    "i64.sub": {
-        "body": "i64.sub",
-        "prefix": "i64.sub"
-    },
-    "i64.mul": {
-        "body": "i64.mul",
-        "prefix": "i64.mul"
-    },
-    "i64.div_s": {
-        "body": "i64.div_s",
-        "prefix": "i64.div_s"
-    },
-    "i64.div_u": {
-        "body": "i64.div_u",
-        "prefix": "i64.div_u"
-    },
-    "i64.rem_s": {
-        "body": "i64.rem_s",
-        "prefix": "i64.rem_s"
-    },
-    "i64.rem_u": {
-        "body": "i64.rem_u",
-        "prefix": "i64.rem_u"
-    },
-    "i64.and": {
-        "body": "i64.and",
-        "prefix": "i64.and"
-    },
-    "i64.or": {
-        "body": "i64.or",
-        "prefix": "i64.or"
-    },
-    "i64.xor": {
-        "body": "i64.xor",
-        "prefix": "i64.xor"
-    },
-    "i64.shl": {
-        "body": "i64.shl",
-        "prefix": "i64.shl"
-    },
-    "i64.shr_s": {
-        "body": "i64.shr_s",
-        "prefix": "i64.shr_s"
-    },
-    "i64.shr_u": {
-        "body": "i64.shr_u",
-        "prefix": "i64.shr_u"
-    },
-    "i64.rotl": {
-        "body": "i64.rotl",
-        "prefix": "i64.rotl"
-    },
-    "i64.rotr": {
-        "body": "i64.rotr",
-        "prefix": "i64.rotr"
-    },
-    "i64.extend_i32_s": {
-        "body": "i64.extend_i32_s",
-        "prefix": "i64.extend_i32_s"
-    },
-    "i64.extend_i32_u": {
-        "body": "i64.extend_i32_u",
-        "prefix": "i64.extend_i32_u"
-    },
-    "i64.trunc_f32_s": {
-        "body": "i64.trunc_f32_s",
-        "prefix": "i64.trunc_f32_s"
-    },
-    "i64.trunc_f32_u": {
-        "body": "i64.trunc_f32_u",
-        "prefix": "i64.trunc_f32_u"
-    },
-    "i64.trunc_f64_s": {
-        "body": "i64.trunc_f64_s",
-        "prefix": "i64.trunc_f64_s"
-    },
-    "i64.trunc_f64_u": {
-        "body": "i64.trunc_f64_u",
-        "prefix": "i64.trunc_f64_u"
-    },
-    "i64.reinterpret_f32": {
-        "body": "i64.reinterpret_f32",
-        "prefix": "i64.reinterpret_f32"
-    },
-    "f32.load": {
-        "body": "f32.load",
-        "prefix": "f32.load"
-    },
-    "f32.store": {
-        "body": "f32.store",
-        "prefix": "f32.store"
-    },
-    "f32.const": {
-        "body": "f32.const ${1:f32}",
-        "prefix": "f32.const"
-    },
-    "f32.eq": {
-        "body": "f32.eq",
-        "prefix": "f32.eq"
-    },
-    "f32.ne": {
-        "body": "f32.ne",
-        "prefix": "f32.ne"
-    },
-    "f32.lt": {
-        "body": "f32.lt",
-        "prefix": "f32.lt"
-    },
-    "f32.gt": {
-        "body": "f32.gt",
-        "prefix": "f32.gt"
-    },
-    "f32.le": {
-        "body": "f32.le",
-        "prefix": "f32.le"
-    },
-    "f32.ge": {
-        "body": "f32.ge",
-        "prefix": "f32.ge"
-    },
-    "f32.abs": {
-        "body": "f32.abs",
-        "prefix": "f32.abs"
-    },
-    "f32.neg": {
-        "body": "f32.neg",
-        "prefix": "f32.neg"
-    },
-    "f32.ceil": {
-        "body": "f32.ceil",
-        "prefix": "f32.ceil"
-    },
-    "f32.floor": {
-        "body": "f32.floor",
-        "prefix": "f32.floor"
-    },
-    "f32.trunc": {
-        "body": "f32.trunc",
-        "prefix": "f32.trunc"
-    },
-    "f32.nearest": {
-        "body": "f32.nearest",
-        "prefix": "f32.nearest"
-    },
-    "f32.sqrt": {
-        "body": "f32.sqrt",
-        "prefix": "f32.sqrt"
-    },
-    "f32.add": {
-        "body": "f32.add",
-        "prefix": "f32.add"
-    },
-    "f32.sub": {
-        "body": "f32.sub",
-        "prefix": "f32.sub"
-    },
-    "f32.mul": {
-        "body": "f32.mul",
-        "prefix": "f32.mul"
-    },
-    "f32.div": {
-        "body": "f32.div",
-        "prefix": "f32.div"
-    },
-    "f32.max": {
-        "body": "f32.max",
-        "prefix": "f32.max"
-    },
-    "f32.min": {
-        "body": "f32.min",
-        "prefix": "f32.min"
-    },
-    "f32.copysign": {
-        "body": "f32.copysign",
-        "prefix": "f32.copysign"
-    },
-    "f32.convert_i32_s": {
-        "body": "f32.convert_i32_s",
-        "prefix": "f32.convert_i32_s"
-    },
-    "f32.convert_i32_u": {
-        "body": "f32.convert_i32_u",
-        "prefix": "f32.convert_i32_u"
-    },
-    "f32.convert_i64_s": {
-        "body": "f32.convert_i64_s",
-        "prefix": "f32.convert_i64_s"
-    },
-    "f32.convert_i64_u": {
-        "body": "f32.convert_i64_u",
-        "prefix": "f32.convert_i64_u"
-    },
-    "f32.demote_f64": {
-        "body": "f32.demote_f64",
-        "prefix": "f32.demote_f64"
-    },
-    "f32.reinterpret_i32": {
-        "body": "f32.reinterpret_i32",
-        "prefix": "f32.reinterpret_i32"
-    },
-    "f64.load": {
-        "body": "f64.load",
-        "prefix": "f64.load"
-    },
-    "f64.store": {
-        "body": "f64.store",
-        "prefix": "f64.store"
-    },
-    "f64.const": {
-        "body": "f64.const ${1:f64}",
-        "prefix": "f64.const"
-    },
-    "f64.eq": {
-        "body": "f64.eq",
-        "prefix": "f64.eq"
-    },
-    "f64.ne": {
-        "body": "f64.ne",
-        "prefix": "f64.ne"
-    },
-    "f64.lt": {
-        "body": "f64.lt",
-        "prefix": "f64.lt"
-    },
-    "f64.gt": {
-        "body": "f64.gt",
-        "prefix": "f64.gt"
-    },
-    "f64.le": {
-        "body": "f64.le",
-        "prefix": "f64.le"
-    },
-    "f64.ge": {
-        "body": "f64.ge",
-        "prefix": "f64.ge"
-    },
-    "f64.abs": {
-        "body": "f64.abs",
-        "prefix": "f64.abs"
-    },
-    "f64.neg": {
-        "body": "f64.neg",
-        "prefix": "f64.neg"
-    },
-    "f64.ceil": {
-        "body": "f64.ceil",
-        "prefix": "f64.ceil"
-    },
-    "f64.floor": {
-        "body": "f64.floor",
-        "prefix": "f64.floor"
-    },
-    "f64.trunc": {
-        "body": "f64.trunc",
-        "prefix": "f64.trunc"
-    },
-    "f64.nearest": {
-        "body": "f64.nearest",
-        "prefix": "f64.nearest"
-    },
-    "f64.sqrt": {
-        "body": "f64.sqrt",
-        "prefix": "f64.sqrt"
-    },
-    "f64.add": {
-        "body": "f64.add",
-        "prefix": "f64.add"
-    },
-    "f64.sub": {
-        "body": "f64.sub",
-        "prefix": "f64.sub"
-    },
-    "f64.mul": {
-        "body": "f64.mul",
-        "prefix": "f64.mul"
-    },
-    "f64.div": {
-        "body": "f64.div",
-        "prefix": "f64.div"
-    },
-    "f64.max": {
-        "body": "f64.max",
-        "prefix": "f64.max"
-    },
-    "f64.min": {
-        "body": "f64.min",
-        "prefix": "f64.min"
-    },
-    "f64.copysign": {
-        "body": "f64.copysign",
-        "prefix": "f64.copysign"
-    },
-    "f64.convert_i32_s": {
-        "body": "f64.convert_i32_s",
-        "prefix": "f64.convert_i32_s"
-    },
-    "f64.convert_i32_u": {
-        "body": "f64.convert_i32_u",
-        "prefix": "f64.convert_i32_u"
-    },
-    "f64.convert_i64_s": {
-        "body": "f64.convert_i64_s",
-        "prefix": "f64.convert_i64_s"
-    },
-    "f64.convert_i64_u": {
-        "body": "f64.convert_i64_u",
-        "prefix": "f64.convert_i64_u"
-    },
-    "f64.demote_f64": {
-        "body": "f64.demote_f64",
-        "prefix": "f64.demote_f64"
-    },
-    "f64.reinterpret_i32": {
-        "body": "f64.reinterpret_i32",
-        "prefix": "f64.reinterpret_i32"
-    }
+  "module": {
+    "body": "module\n\t${1:}\n",
+    "prefix": "module"
+  },
+  "export": {
+    "body": "export ${1:\"name\"} (func ${2:$$name})",
+    "prefix": "export"
+  },
+  "func-i32-0": {
+    "body": "func ${1:$$name} (result ${2:i32})\n\t${3:}\n",
+    "prefix": "func"
+  },
+  "func-i32-1": {
+    "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (result ${4:i32})\n\t${5:}\n",
+    "prefix": "func"
+  },
+  "func-i32-2": {
+    "body": "func ${1:$$name} (param ${2:$$lhs} ${3:i32}) (param ${4:$$rhs} ${5:i32}) (result ${6:i32})\n\t${7:}\n",
+    "prefix": "func"
+  },
+  "i32.trunc_sat_f32_s": {
+    "body": "i32.trunc_sat_f32_s",
+    "prefix": "i32.trunc_sat_f32_s"
+  },
+  "i32.trunc_sat_f32_u": {
+    "body": "i32.trunc_sat_f32_u",
+    "prefix": "i32.trunc_sat_f32_u"
+  },
+  "i32.trunc_sat_f64_s": {
+    "body": "i32.trunc_sat_f64_s",
+    "prefix": "i32.trunc_sat_f64_s"
+  },
+  "i32.trunc_sat_f64_u": {
+    "body": "i32.trunc_sat_f64_u",
+    "prefix": "i32.trunc_sat_f64_u"
+  },
+  "i64.trunc_sat_f32_s": {
+    "body": "i64.trunc_sat_f32_s",
+    "prefix": "i64.trunc_sat_f32_s"
+  },
+  "i64.trunc_sat_f32_u": {
+    "body": "i64.trunc_sat_f32_u",
+    "prefix": "i64.trunc_sat_f32_u"
+  },
+  "i64.trunc_sat_f64_s": {
+    "body": "i64.trunc_sat_f64_s",
+    "prefix": "i64.trunc_sat_f64_s"
+  },
+  "i64.trunc_sat_f64_u": {
+    "body": "i64.trunc_sat_f64_u",
+    "prefix": "i64.trunc_sat_f64_u"
+  },
+  "i32.extend8_s": {
+    "body": "i32.extend8_s",
+    "prefix": "i32.extend8_s"
+  },
+  "i32.extend16_s": {
+    "body": "i32.extend16_s",
+    "prefix": "i32.extend16_s"
+  },
+  "i64.extend8_s": {
+    "body": "i64.extend8_s",
+    "prefix": "i64.extend8_s"
+  },
+  "i64.extend16_s": {
+    "body": "i64.extend16_s",
+    "prefix": "i64.extend16_s"
+  },
+  "i64.extend32_s": {
+    "body": "i64.extend32_s",
+    "prefix": "i64.extend32_s"
+  },
+  "memory.copy": {
+    "body": "memory.copy",
+    "prefix": "memory.copy"
+  },
+  "memory.fill": {
+    "body": "memory.fill",
+    "prefix": "memory.fill"
+  },
+  "memory.init": {
+    "body": "memory.init",
+    "prefix": "memory.init"
+  },
+  "memory.drop": {
+    "body": "memory.drop",
+    "prefix": "memory.drop"
+  },
+  "v128": {
+    "body": "v128",
+    "prefix": "v128"
+  },
+  "v128.const": {
+    "body": "v128.const ",
+    "prefix": "v128.const"
+  },
+  "v128.and": {
+    "body": "v128.and",
+    "prefix": "v128.and"
+  },
+  "v128.or": {
+    "body": "v128.or",
+    "prefix": "v128.or"
+  },
+  "v128.xor": {
+    "body": "v128.xor",
+    "prefix": "v128.xor"
+  },
+  "v128.not": {
+    "body": "v128.not",
+    "prefix": "v128.not"
+  },
+  "v128.andnot": {
+    "body": "v128.andnot",
+    "prefix": "v128.andnot"
+  },
+  "v128.bitselect": {
+    "body": "v128.bitselect",
+    "prefix": "v128.bitselect"
+  },
+  "v128.load": {
+    "body": "v128.load",
+    "prefix": "v128.load"
+  },
+  "v128.store": {
+    "body": "v128.store",
+    "prefix": "v128.store"
+  },
+  "i8x16.splat": {
+    "body": "i8x16.splat",
+    "prefix": "i8x16.splat"
+  },
+  "i8x16.replace_lane": {
+    "body": "i8x16.replace_lane",
+    "prefix": "i8x16.replace_lane"
+  },
+  "i8x16.extract_lane_s": {
+    "body": "i8x16.extract_lane_s",
+    "prefix": "i8x16.extract_lane_s"
+  },
+  "i8x16.extract_lane_u": {
+    "body": "i8x16.extract_lane_u",
+    "prefix": "i8x16.extract_lane_u"
+  },
+  "i8x16.any_true": {
+    "body": "i8x16.any_true",
+    "prefix": "i8x16.any_true"
+  },
+  "i8x16.all_true": {
+    "body": "i8x16.all_true",
+    "prefix": "i8x16.all_true"
+  },
+  "i8x16.add": {
+    "body": "i8x16.add",
+    "prefix": "i8x16.add"
+  },
+  "i8x16.add_saturate_s": {
+    "body": "i8x16.add_saturate_s",
+    "prefix": "i8x16.add_saturate_s"
+  },
+  "i8x16.add_saturate_u": {
+    "body": "i8x16.add_saturate_u",
+    "prefix": "i8x16.add_saturate_u"
+  },
+  "i8x16.sub": {
+    "body": "i8x16.sub",
+    "prefix": "i8x16.sub"
+  },
+  "i8x16.sub_saturate_s": {
+    "body": "i8x16.sub_saturate_s",
+    "prefix": "i8x16.sub_saturate_s"
+  },
+  "i8x16.sub_saturate_u": {
+    "body": "i8x16.sub_saturate_u",
+    "prefix": "i8x16.sub_saturate_u"
+  },
+  "i8x16.mul": {
+    "body": "i8x16.mul",
+    "prefix": "i8x16.mul"
+  },
+  "i8x16.neg": {
+    "body": "i8x16.neg",
+    "prefix": "i8x16.neg"
+  },
+  "i8x16.shl": {
+    "body": "i8x16.shl",
+    "prefix": "i8x16.shl"
+  },
+  "i8x16.shr_s": {
+    "body": "i8x16.shr_s",
+    "prefix": "i8x16.shr_s"
+  },
+  "i8x16.shr_u": {
+    "body": "i8x16.shr_u",
+    "prefix": "i8x16.shr_u"
+  },
+  "i8x16.eq": {
+    "body": "i8x16.eq",
+    "prefix": "i8x16.eq"
+  },
+  "i8x16.ne": {
+    "body": "i8x16.ne",
+    "prefix": "i8x16.ne"
+  },
+  "i8x16.lt_s": {
+    "body": "i8x16.lt_s",
+    "prefix": "i8x16.lt_s"
+  },
+  "i8x16.lt_u": {
+    "body": "i8x16.lt_u",
+    "prefix": "i8x16.lt_u"
+  },
+  "i8x16.le_s": {
+    "body": "i8x16.le_s",
+    "prefix": "i8x16.le_s"
+  },
+  "i8x16.le_u": {
+    "body": "i8x16.le_u",
+    "prefix": "i8x16.le_u"
+  },
+  "i8x16.gt_s": {
+    "body": "i8x16.gt_s",
+    "prefix": "i8x16.gt_s"
+  },
+  "i8x16.gt_u": {
+    "body": "i8x16.gt_u",
+    "prefix": "i8x16.gt_u"
+  },
+  "i8x16.ge_s": {
+    "body": "i8x16.ge_s",
+    "prefix": "i8x16.ge_s"
+  },
+  "i8x16.ge_u": {
+    "body": "i8x16.ge_u",
+    "prefix": "i8x16.ge_u"
+  },
+  "i8x16.min_s": {
+    "body": "i8x16.min_s",
+    "prefix": "i8x16.min_s"
+  },
+  "i8x16.min_u": {
+    "body": "i8x16.min_u",
+    "prefix": "i8x16.min_u"
+  },
+  "i8x16.max_s": {
+    "body": "i8x16.max_s",
+    "prefix": "i8x16.max_s"
+  },
+  "i8x16.max_u": {
+    "body": "i8x16.max_u",
+    "prefix": "i8x16.max_u"
+  },
+  "i8x16.avgr_u": {
+    "body": "i8x16.avgr_u",
+    "prefix": "i8x16.avgr_u"
+  },
+  "i8x16.narrow_i16x8_s": {
+    "body": "i8x16.narrow_i16x8_s",
+    "prefix": "i8x16.narrow_i16x8_s"
+  },
+  "i8x16.narrow_i16x8_u": {
+    "body": "i8x16.narrow_i16x8_u",
+    "prefix": "i8x16.narrow_i16x8_u"
+  },
+  "i16x8.splat": {
+    "body": "i16x8.splat",
+    "prefix": "i16x8.splat"
+  },
+  "i16x8.load_8x8_s": {
+    "body": "i16x8.load_8x8_s",
+    "prefix": "i16x8.load_8x8_s"
+  },
+  "i16x8.load_8x8_u": {
+    "body": "i16x8.load_8x8_u",
+    "prefix": "i16x8.load_8x8_u"
+  },
+  "i16x8.replace_lane": {
+    "body": "i16x8.replace_lane",
+    "prefix": "i16x8.replace_lane"
+  },
+  "i16x8.extract_lane_s": {
+    "body": "i16x8.extract_lane_s",
+    "prefix": "i16x8.extract_lane_s"
+  },
+  "i16x8.extract_lane_u": {
+    "body": "i16x8.extract_lane_u",
+    "prefix": "i16x8.extract_lane_u"
+  },
+  "i16x8.any_true": {
+    "body": "i16x8.any_true",
+    "prefix": "i16x8.any_true"
+  },
+  "i16x8.all_true": {
+    "body": "i16x8.all_true",
+    "prefix": "i16x8.all_true"
+  },
+  "i16x8.add": {
+    "body": "i16x8.add",
+    "prefix": "i16x8.add"
+  },
+  "i16x8.add_saturate_s": {
+    "body": "i16x8.add_saturate_s",
+    "prefix": "i16x8.add_saturate_s"
+  },
+  "i16x8.add_saturate_u": {
+    "body": "i16x8.add_saturate_u",
+    "prefix": "i16x8.add_saturate_u"
+  },
+  "i16x8.sub": {
+    "body": "i16x8.sub",
+    "prefix": "i16x8.sub"
+  },
+  "i16x8.sub_saturate_s": {
+    "body": "i16x8.sub_saturate_s",
+    "prefix": "i16x8.sub_saturate_s"
+  },
+  "i16x8.sub_saturate_u": {
+    "body": "i16x8.sub_saturate_u",
+    "prefix": "i16x8.sub_saturate_u"
+  },
+  "i16x8.mul": {
+    "body": "i16x8.mul",
+    "prefix": "i16x8.mul"
+  },
+  "i16x8.neg": {
+    "body": "i16x8.neg",
+    "prefix": "i16x8.neg"
+  },
+  "i16x8.shl": {
+    "body": "i16x8.shl",
+    "prefix": "i16x8.shl"
+  },
+  "i16x8.shr_s": {
+    "body": "i16x8.shr_s",
+    "prefix": "i16x8.shr_s"
+  },
+  "i16x8.shr_u": {
+    "body": "i16x8.shr_u",
+    "prefix": "i16x8.shr_u"
+  },
+  "i16x8.eq": {
+    "body": "i16x8.eq",
+    "prefix": "i16x8.eq"
+  },
+  "i16x8.ne": {
+    "body": "i16x8.ne",
+    "prefix": "i16x8.ne"
+  },
+  "i16x8.lt_s": {
+    "body": "i16x8.lt_s",
+    "prefix": "i16x8.lt_s"
+  },
+  "i16x8.lt_u": {
+    "body": "i16x8.lt_u",
+    "prefix": "i16x8.lt_u"
+  },
+  "i16x8.le_s": {
+    "body": "i16x8.le_s",
+    "prefix": "i16x8.le_s"
+  },
+  "i16x8.le_u": {
+    "body": "i16x8.le_u",
+    "prefix": "i16x8.le_u"
+  },
+  "i16x8.gt_s": {
+    "body": "i16x8.gt_s",
+    "prefix": "i16x8.gt_s"
+  },
+  "i16x8.gt_u": {
+    "body": "i16x8.gt_u",
+    "prefix": "i16x8.gt_u"
+  },
+  "i16x8.ge_s": {
+    "body": "i16x8.ge_s",
+    "prefix": "i16x8.ge_s"
+  },
+  "i16x8.ge_u": {
+    "body": "i16x8.ge_u",
+    "prefix": "i16x8.ge_u"
+  },
+  "i16x8.min_s": {
+    "body": "i16x8.min_s",
+    "prefix": "i16x8.min_s"
+  },
+  "i16x8.min_u": {
+    "body": "i16x8.min_u",
+    "prefix": "i16x8.min_u"
+  },
+  "i16x8.max_s": {
+    "body": "i16x8.max_s",
+    "prefix": "i16x8.max_s"
+  },
+  "i16x8.max_u": {
+    "body": "i16x8.max_u",
+    "prefix": "i16x8.max_u"
+  },
+  "i16x8.avgr_u": {
+    "body": "i16x8.avgr_u",
+    "prefix": "i16x8.avgr_u"
+  },
+  "i16x8.narrow_i32x4_s": {
+    "body": "i16x8.narrow_i32x4_s",
+    "prefix": "i16x8.narrow_i32x4_s"
+  },
+  "i16x8.narrow_i32x4_u": {
+    "body": "i16x8.narrow_i32x4_u",
+    "prefix": "i16x8.narrow_i32x4_u"
+  },
+  "i16x8.widen_low_i8x16_s": {
+    "body": "i16x8.widen_low_i8x16_s",
+    "prefix": "i16x8.widen_low_i8x16_s"
+  },
+  "i16x8.widen_low_i8x16_u": {
+    "body": "i16x8.widen_low_i8x16_u",
+    "prefix": "i16x8.widen_low_i8x16_u"
+  },
+  "i16x8.widen_high_i8x16_s": {
+    "body": "i16x8.widen_high_i8x16_s",
+    "prefix": "i16x8.widen_high_i8x16_s"
+  },
+  "i16x8.widen_high_i8x16_u": {
+    "body": "i16x8.widen_high_i8x16_u",
+    "prefix": "i16x8.widen_high_i8x16_u"
+  },
+  "i32x4.splat": {
+    "body": "i32x4.splat",
+    "prefix": "i32x4.splat"
+  },
+  "i32x4.load_16x4_s": {
+    "body": "i32x4.load_16x4_s",
+    "prefix": "i32x4.load_16x4_s"
+  },
+  "i32x4.load_16x4_u": {
+    "body": "i32x4.load_16x4_u",
+    "prefix": "i32x4.load_16x4_u"
+  },
+  "i32x4.replace_lane": {
+    "body": "i32x4.replace_lane",
+    "prefix": "i32x4.replace_lane"
+  },
+  "i32x4.extract_lane": {
+    "body": "i32x4.extract_lane",
+    "prefix": "i32x4.extract_lane"
+  },
+  "i32x4.any_true": {
+    "body": "i32x4.any_true",
+    "prefix": "i32x4.any_true"
+  },
+  "i32x4.all_true": {
+    "body": "i32x4.all_true",
+    "prefix": "i32x4.all_true"
+  },
+  "i32x4.add": {
+    "body": "i32x4.add",
+    "prefix": "i32x4.add"
+  },
+  "i32x4.sub": {
+    "body": "i32x4.sub",
+    "prefix": "i32x4.sub"
+  },
+  "i32x4.mul": {
+    "body": "i32x4.mul",
+    "prefix": "i32x4.mul"
+  },
+  "i32x4.neg": {
+    "body": "i32x4.neg",
+    "prefix": "i32x4.neg"
+  },
+  "i32x4.shl": {
+    "body": "i32x4.shl",
+    "prefix": "i32x4.shl"
+  },
+  "i32x4.shr_s": {
+    "body": "i32x4.shr_s",
+    "prefix": "i32x4.shr_s"
+  },
+  "i32x4.shr_u": {
+    "body": "i32x4.shr_u",
+    "prefix": "i32x4.shr_u"
+  },
+  "i32x4.eq": {
+    "body": "i32x4.eq",
+    "prefix": "i32x4.eq"
+  },
+  "i32x4.ne": {
+    "body": "i32x4.ne",
+    "prefix": "i32x4.ne"
+  },
+  "i32x4.lt_s": {
+    "body": "i32x4.lt_s",
+    "prefix": "i32x4.lt_s"
+  },
+  "i32x4.lt_u": {
+    "body": "i32x4.lt_u",
+    "prefix": "i32x4.lt_u"
+  },
+  "i32x4.le_s": {
+    "body": "i32x4.le_s",
+    "prefix": "i32x4.le_s"
+  },
+  "i32x4.le_u": {
+    "body": "i32x4.le_u",
+    "prefix": "i32x4.le_u"
+  },
+  "i32x4.gt_s": {
+    "body": "i32x4.gt_s",
+    "prefix": "i32x4.gt_s"
+  },
+  "i32x4.gt_u": {
+    "body": "i32x4.gt_u",
+    "prefix": "i32x4.gt_u"
+  },
+  "i32x4.ge_s": {
+    "body": "i32x4.ge_s",
+    "prefix": "i32x4.ge_s"
+  },
+  "i32x4.ge_u": {
+    "body": "i32x4.ge_u",
+    "prefix": "i32x4.ge_u"
+  },
+  "i32x4.min_s": {
+    "body": "i32x4.min_s",
+    "prefix": "i32x4.min_s"
+  },
+  "i32x4.min_u": {
+    "body": "i32x4.min_u",
+    "prefix": "i32x4.min_u"
+  },
+  "i32x4.max_s": {
+    "body": "i32x4.max_s",
+    "prefix": "i32x4.max_s"
+  },
+  "i32x4.max_u": {
+    "body": "i32x4.max_u",
+    "prefix": "i32x4.max_u"
+  },
+  "i32x4.trunc_sat_f32x4_s": {
+    "body": "i32x4.trunc_sat_f32x4_s",
+    "prefix": "i32x4.trunc_sat_f32x4_s"
+  },
+  "i32x4.trunc_sat_f32x4_u": {
+    "body": "i32x4.trunc_sat_f32x4_u",
+    "prefix": "i32x4.trunc_sat_f32x4_u"
+  },
+  "i32x4.widen_low_i16x8_s": {
+    "body": "i32x4.widen_low_i16x8_s",
+    "prefix": "i32x4.widen_low_i16x8_s"
+  },
+  "i32x4.widen_low_i16x8_u": {
+    "body": "i32x4.widen_low_i16x8_u",
+    "prefix": "i32x4.widen_low_i16x8_u"
+  },
+  "i32x4.widen_high_i16x8_s": {
+    "body": "i32x4.widen_high_i16x8_s",
+    "prefix": "i32x4.widen_high_i16x8_s"
+  },
+  "i32x4.widen_high_i16x8_u": {
+    "body": "i32x4.widen_high_i16x8_u",
+    "prefix": "i32x4.widen_high_i16x8_u"
+  },
+  "i64x2.splat": {
+    "body": "i64x2.splat",
+    "prefix": "i64x2.splat"
+  },
+  "i64x2.load32x2_s": {
+    "body": "i64x2.load32x2_s",
+    "prefix": "i64x2.load32x2_s"
+  },
+  "i64x2.load32x2_u": {
+    "body": "i64x2.load32x2_u",
+    "prefix": "i64x2.load32x2_u"
+  },
+  "i64x2.replace_lane": {
+    "body": "i64x2.replace_lane",
+    "prefix": "i64x2.replace_lane"
+  },
+  "i64x2.extract_lane": {
+    "body": "i64x2.extract_lane",
+    "prefix": "i64x2.extract_lane"
+  },
+  "i64x2.add": {
+    "body": "i64x2.add",
+    "prefix": "i64x2.add"
+  },
+  "i64x2.sub": {
+    "body": "i64x2.sub",
+    "prefix": "i64x2.sub"
+  },
+  "i64x2.mul": {
+    "body": "i64x2.mul",
+    "prefix": "i64x2.mul"
+  },
+  "i64x2.neg": {
+    "body": "i64x2.neg",
+    "prefix": "i64x2.neg"
+  },
+  "i64x2.shl": {
+    "body": "i64x2.shl",
+    "prefix": "i64x2.shl"
+  },
+  "i64x2.shr_s": {
+    "body": "i64x2.shr_s",
+    "prefix": "i64x2.shr_s"
+  },
+  "i64x2.shr_u": {
+    "body": "i64x2.shr_u",
+    "prefix": "i64x2.shr_u"
+  },
+  "f32x4.splat": {
+    "body": "f32x4.splat",
+    "prefix": "f32x4.splat"
+  },
+  "f32x4.replace_lane": {
+    "body": "f32x4.replace_lane",
+    "prefix": "f32x4.replace_lane"
+  },
+  "f32x4.extract_lane": {
+    "body": "f32x4.extract_lane",
+    "prefix": "f32x4.extract_lane"
+  },
+  "f32x4.add": {
+    "body": "f32x4.add",
+    "prefix": "f32x4.add"
+  },
+  "f32x4.sub": {
+    "body": "f32x4.sub",
+    "prefix": "f32x4.sub"
+  },
+  "f32x4.mul": {
+    "body": "f32x4.mul",
+    "prefix": "f32x4.mul"
+  },
+  "f32x4.neg": {
+    "body": "f32x4.neg",
+    "prefix": "f32x4.neg"
+  },
+  "f32x4.eq": {
+    "body": "f32x4.eq",
+    "prefix": "f32x4.eq"
+  },
+  "f32x4.ne": {
+    "body": "f32x4.ne",
+    "prefix": "f32x4.ne"
+  },
+  "f32x4.lt": {
+    "body": "f32x4.lt",
+    "prefix": "f32x4.lt"
+  },
+  "f32x4.le": {
+    "body": "f32x4.le",
+    "prefix": "f32x4.le"
+  },
+  "f32x4.gt": {
+    "body": "f32x4.gt",
+    "prefix": "f32x4.gt"
+  },
+  "f32x4.ge": {
+    "body": "f32x4.ge",
+    "prefix": "f32x4.ge"
+  },
+  "f32x4.abs": {
+    "body": "f32x4.abs",
+    "prefix": "f32x4.abs"
+  },
+  "f32x4.min": {
+    "body": "f32x4.min",
+    "prefix": "f32x4.min"
+  },
+  "f32x4.max": {
+    "body": "f32x4.max",
+    "prefix": "f32x4.max"
+  },
+  "f32x4.div": {
+    "body": "f32x4.div",
+    "prefix": "f32x4.div"
+  },
+  "f32x4.sqrt": {
+    "body": "f32x4.sqrt",
+    "prefix": "f32x4.sqrt"
+  },
+  "f32x4.convert_i32x4_s": {
+    "body": "f32x4.convert_i32x4_s",
+    "prefix": "f32x4.convert_i32x4_s"
+  },
+  "f32x4.convert_i32x4_u": {
+    "body": "f32x4.convert_i32x4_u",
+    "prefix": "f32x4.convert_i32x4_u"
+  },
+  "f64x2.splat": {
+    "body": "f64x2.splat",
+    "prefix": "f64x2.splat"
+  },
+  "f64x2.replace_lane": {
+    "body": "f64x2.replace_lane",
+    "prefix": "f64x2.replace_lane"
+  },
+  "f64x2.extract_lane": {
+    "body": "f64x2.extract_lane",
+    "prefix": "f64x2.extract_lane"
+  },
+  "f64x2.add": {
+    "body": "f64x2.add",
+    "prefix": "f64x2.add"
+  },
+  "f64x2.sub": {
+    "body": "f64x2.sub",
+    "prefix": "f64x2.sub"
+  },
+  "f64x2.mul": {
+    "body": "f64x2.mul",
+    "prefix": "f64x2.mul"
+  },
+  "f64x2.neg": {
+    "body": "f64x2.neg",
+    "prefix": "f64x2.neg"
+  },
+  "f64x2.eq": {
+    "body": "f64x2.eq",
+    "prefix": "f64x2.eq"
+  },
+  "f64x2.ne": {
+    "body": "f64x2.ne",
+    "prefix": "f64x2.ne"
+  },
+  "f64x2.lt": {
+    "body": "f64x2.lt",
+    "prefix": "f64x2.lt"
+  },
+  "f64x2.le": {
+    "body": "f64x2.le",
+    "prefix": "f64x2.le"
+  },
+  "f64x2.gt": {
+    "body": "f64x2.gt",
+    "prefix": "f64x2.gt"
+  },
+  "f64x2.ge": {
+    "body": "f64x2.ge",
+    "prefix": "f64x2.ge"
+  },
+  "f64x2.abs": {
+    "body": "f64x2.abs",
+    "prefix": "f64x2.abs"
+  },
+  "f64x2.min": {
+    "body": "f64x2.min",
+    "prefix": "f64x2.min"
+  },
+  "f64x2.max": {
+    "body": "f64x2.max",
+    "prefix": "f64x2.max"
+  },
+  "f64x2.div": {
+    "body": "f64x2.div",
+    "prefix": "f64x2.div"
+  },
+  "f64x2.sqrt": {
+    "body": "f64x2.sqrt",
+    "prefix": "f64x2.sqrt"
+  },
+  "v8x16.load_splat": {
+    "body": "v8x16.load_splat",
+    "prefix": "v8x16.load_splat"
+  },
+  "v8x16.shuffle": {
+    "body": "v8x16.shuffle",
+    "prefix": "v8x16.shuffle"
+  },
+  "v8x16.swizzle": {
+    "body": "v8x16.swizzle",
+    "prefix": "v8x16.swizzle"
+  },
+  "v16x8.load_splat": {
+    "body": "v16x8.load_splat",
+    "prefix": "v16x8.load_splat"
+  },
+  "v32x4.load_splat": {
+    "body": "v32x4.load_splat",
+    "prefix": "v32x4.load_splat"
+  },
+  "v64x2.load_splat": {
+    "body": "v64x2.load_splat",
+    "prefix": "v64x2.load_splat"
+  },
+  "i32.atomic.load": {
+    "body": "i32.atomic.load",
+    "prefix": "i32.atomic.load"
+  },
+  "i32.atomic.load8_u": {
+    "body": "i32.atomic.load8_u",
+    "prefix": "i32.atomic.load8_u"
+  },
+  "i32.atomic.load16_u": {
+    "body": "i32.atomic.load16_u",
+    "prefix": "i32.atomic.load16_u"
+  },
+  "i32.atomic.store": {
+    "body": "i32.atomic.store",
+    "prefix": "i32.atomic.store"
+  },
+  "i32.atomic.store8": {
+    "body": "i32.atomic.store8",
+    "prefix": "i32.atomic.store8"
+  },
+  "i32.atomic.store16": {
+    "body": "i32.atomic.store16",
+    "prefix": "i32.atomic.store16"
+  },
+  "i32.atomic.rmw.add": {
+    "body": "i32.atomic.rmw.add",
+    "prefix": "i32.atomic.rmw.add"
+  },
+  "i32.atomic.rmw.sub": {
+    "body": "i32.atomic.rmw.sub",
+    "prefix": "i32.atomic.rmw.sub"
+  },
+  "i32.atomic.rmw.and": {
+    "body": "i32.atomic.rmw.and",
+    "prefix": "i32.atomic.rmw.and"
+  },
+  "i32.atomic.rmw.or": {
+    "body": "i32.atomic.rmw.or",
+    "prefix": "i32.atomic.rmw.or"
+  },
+  "i32.atomic.rmw.xor": {
+    "body": "i32.atomic.rmw.xor",
+    "prefix": "i32.atomic.rmw.xor"
+  },
+  "i32.atomic.rmw.xchg": {
+    "body": "i32.atomic.rmw.xchg",
+    "prefix": "i32.atomic.rmw.xchg"
+  },
+  "i32.atomic.rmw.cmpxchg": {
+    "body": "i32.atomic.rmw.cmpxchg",
+    "prefix": "i32.atomic.rmw.cmpxchg"
+  },
+  "i32.atomic.rmw8.add_u": {
+    "body": "i32.atomic.rmw8.add_u",
+    "prefix": "i32.atomic.rmw8.add_u"
+  },
+  "i32.atomic.rmw8.sub_u": {
+    "body": "i32.atomic.rmw8.sub_u",
+    "prefix": "i32.atomic.rmw8.sub_u"
+  },
+  "i32.atomic.rmw8.and_u": {
+    "body": "i32.atomic.rmw8.and_u",
+    "prefix": "i32.atomic.rmw8.and_u"
+  },
+  "i32.atomic.rmw8.or_u": {
+    "body": "i32.atomic.rmw8.or_u",
+    "prefix": "i32.atomic.rmw8.or_u"
+  },
+  "i32.atomic.rmw8.xor_u": {
+    "body": "i32.atomic.rmw8.xor_u",
+    "prefix": "i32.atomic.rmw8.xor_u"
+  },
+  "i32.atomic.rmw8.xchg_u": {
+    "body": "i32.atomic.rmw8.xchg_u",
+    "prefix": "i32.atomic.rmw8.xchg_u"
+  },
+  "i32.atomic.rmw8.cmpxchg_u": {
+    "body": "i32.atomic.rmw8.cmpxchg_u",
+    "prefix": "i32.atomic.rmw8.cmpxchg_u"
+  },
+  "i32.atomic.rmw16.add_u": {
+    "body": "i32.atomic.rmw16.add_u",
+    "prefix": "i32.atomic.rmw16.add_u"
+  },
+  "i32.atomic.rmw16.sub_u": {
+    "body": "i32.atomic.rmw16.sub_u",
+    "prefix": "i32.atomic.rmw16.sub_u"
+  },
+  "i32.atomic.rmw16.and_u": {
+    "body": "i32.atomic.rmw16.and_u",
+    "prefix": "i32.atomic.rmw16.and_u"
+  },
+  "i32.atomic.rmw16.or_u": {
+    "body": "i32.atomic.rmw16.or_u",
+    "prefix": "i32.atomic.rmw16.or_u"
+  },
+  "i32.atomic.rmw16.xor_u": {
+    "body": "i32.atomic.rmw16.xor_u",
+    "prefix": "i32.atomic.rmw16.xor_u"
+  },
+  "i32.atomic.rmw16.xchg_u": {
+    "body": "i32.atomic.rmw16.xchg_u",
+    "prefix": "i32.atomic.rmw16.xchg_u"
+  },
+  "i32.atomic.rmw16.cmpxchg_u": {
+    "body": "i32.atomic.rmw16.cmpxchg_u",
+    "prefix": "i32.atomic.rmw16.cmpxchg_u"
+  },
+  "i32.atomic.wait": {
+    "body": "i32.atomic.wait",
+    "prefix": "i32.atomic.wait"
+  },
+  "i64.atomic.load": {
+    "body": "i64.atomic.load",
+    "prefix": "i64.atomic.load"
+  },
+  "i64.atomic.load8_u": {
+    "body": "i64.atomic.load8_u",
+    "prefix": "i64.atomic.load8_u"
+  },
+  "i64.atomic.load16_u": {
+    "body": "i64.atomic.load16_u",
+    "prefix": "i64.atomic.load16_u"
+  },
+  "i64.atomic.load32_u": {
+    "body": "i64.atomic.load32_u",
+    "prefix": "i64.atomic.load32_u"
+  },
+  "i64.atomic.store": {
+    "body": "i64.atomic.store",
+    "prefix": "i64.atomic.store"
+  },
+  "i64.atomic.store8": {
+    "body": "i64.atomic.store8",
+    "prefix": "i64.atomic.store8"
+  },
+  "i64.atomic.store16": {
+    "body": "i64.atomic.store16",
+    "prefix": "i64.atomic.store16"
+  },
+  "i64.atomic.store32": {
+    "body": "i64.atomic.store32",
+    "prefix": "i64.atomic.store32"
+  },
+  "i64.atomic.rmw.add": {
+    "body": "i64.atomic.rmw.add",
+    "prefix": "i64.atomic.rmw.add"
+  },
+  "i64.atomic.rmw.sub": {
+    "body": "i64.atomic.rmw.sub",
+    "prefix": "i64.atomic.rmw.sub"
+  },
+  "i64.atomic.rmw.and": {
+    "body": "i64.atomic.rmw.and",
+    "prefix": "i64.atomic.rmw.and"
+  },
+  "i64.atomic.rmw.or": {
+    "body": "i64.atomic.rmw.or",
+    "prefix": "i64.atomic.rmw.or"
+  },
+  "i64.atomic.rmw.xor": {
+    "body": "i64.atomic.rmw.xor",
+    "prefix": "i64.atomic.rmw.xor"
+  },
+  "i64.atomic.rmw.xchg": {
+    "body": "i64.atomic.rmw.xchg",
+    "prefix": "i64.atomic.rmw.xchg"
+  },
+  "i64.atomic.rmw.cmpxchg": {
+    "body": "i64.atomic.rmw.cmpxchg",
+    "prefix": "i64.atomic.rmw.cmpxchg"
+  },
+  "i64.atomic.rmw8.add_u": {
+    "body": "i64.atomic.rmw8.add_u",
+    "prefix": "i64.atomic.rmw8.add_u"
+  },
+  "i64.atomic.rmw8.sub_u": {
+    "body": "i64.atomic.rmw8.sub_u",
+    "prefix": "i64.atomic.rmw8.sub_u"
+  },
+  "i64.atomic.rmw8.and_u": {
+    "body": "i64.atomic.rmw8.and_u",
+    "prefix": "i64.atomic.rmw8.and_u"
+  },
+  "i64.atomic.rmw8.or_u": {
+    "body": "i64.atomic.rmw8.or_u",
+    "prefix": "i64.atomic.rmw8.or_u"
+  },
+  "i64.atomic.rmw8.xor_u": {
+    "body": "i64.atomic.rmw8.xor_u",
+    "prefix": "i64.atomic.rmw8.xor_u"
+  },
+  "i64.atomic.rmw8.xchg_u": {
+    "body": "i64.atomic.rmw8.xchg_u",
+    "prefix": "i64.atomic.rmw8.xchg_u"
+  },
+  "i64.atomic.rmw8.cmpxchg_u": {
+    "body": "i64.atomic.rmw8.cmpxchg_u",
+    "prefix": "i64.atomic.rmw8.cmpxchg_u"
+  },
+  "i64.atomic.rmw16.add_u": {
+    "body": "i64.atomic.rmw16.add_u",
+    "prefix": "i64.atomic.rmw16.add_u"
+  },
+  "i64.atomic.rmw16.sub_u": {
+    "body": "i64.atomic.rmw16.sub_u",
+    "prefix": "i64.atomic.rmw16.sub_u"
+  },
+  "i64.atomic.rmw16.and_u": {
+    "body": "i64.atomic.rmw16.and_u",
+    "prefix": "i64.atomic.rmw16.and_u"
+  },
+  "i64.atomic.rmw16.or_u": {
+    "body": "i64.atomic.rmw16.or_u",
+    "prefix": "i64.atomic.rmw16.or_u"
+  },
+  "i64.atomic.rmw16.xor_u": {
+    "body": "i64.atomic.rmw16.xor_u",
+    "prefix": "i64.atomic.rmw16.xor_u"
+  },
+  "i64.atomic.rmw16.xchg_u": {
+    "body": "i64.atomic.rmw16.xchg_u",
+    "prefix": "i64.atomic.rmw16.xchg_u"
+  },
+  "i64.atomic.rmw16.cmpxchg_u": {
+    "body": "i64.atomic.rmw16.cmpxchg_u",
+    "prefix": "i64.atomic.rmw16.cmpxchg_u"
+  },
+  "i64.atomic.rmw32.add_u": {
+    "body": "i64.atomic.rmw32.add_u",
+    "prefix": "i64.atomic.rmw32.add_u"
+  },
+  "i64.atomic.rmw32.sub_u": {
+    "body": "i64.atomic.rmw32.sub_u",
+    "prefix": "i64.atomic.rmw32.sub_u"
+  },
+  "i64.atomic.rmw32.and_u": {
+    "body": "i64.atomic.rmw32.and_u",
+    "prefix": "i64.atomic.rmw32.and_u"
+  },
+  "i64.atomic.rmw32.or_u": {
+    "body": "i64.atomic.rmw32.or_u",
+    "prefix": "i64.atomic.rmw32.or_u"
+  },
+  "i64.atomic.rmw32.xor_u": {
+    "body": "i64.atomic.rmw32.xor_u",
+    "prefix": "i64.atomic.rmw32.xor_u"
+  },
+  "i64.atomic.rmw32.xchg_u": {
+    "body": "i64.atomic.rmw32.xchg_u",
+    "prefix": "i64.atomic.rmw32.xchg_u"
+  },
+  "i64.atomic.rmw32.cmpxchg_u": {
+    "body": "i64.atomic.rmw32.cmpxchg_u",
+    "prefix": "i64.atomic.rmw32.cmpxchg_u"
+  },
+  "i64.atomic.wait": {
+    "body": "i64.atomic.wait",
+    "prefix": "i64.atomic.wait"
+  },
+  "atomic.notify": {
+    "body": "atomic.notify",
+    "prefix": "atomic.notify"
+  },
+  "atomic.fence": {
+    "body": "atomic.fence",
+    "prefix": "atomic.fence"
+  },
+  "anyref": {
+    "body": "anyref",
+    "prefix": "anyref"
+  },
+  "funcref": {
+    "body": "funcref",
+    "prefix": "funcref"
+  },
+  "nullref": {
+    "body": "nullref",
+    "prefix": "nullref"
+  },
+  "ref.null": {
+    "body": "ref.null",
+    "prefix": "ref.null"
+  },
+  "ref.is_null": {
+    "body": "ref.is_null",
+    "prefix": "ref.is_null"
+  },
+  "ref.func": {
+    "body": "ref.func",
+    "prefix": "ref.func"
+  },
+  "table.get": {
+    "body": "table.get",
+    "prefix": "table.get"
+  },
+  "table.size": {
+    "body": "table.size",
+    "prefix": "table.size"
+  },
+  "table.grow": {
+    "body": "table.grow",
+    "prefix": "table.grow"
+  },
+  "table.fill": {
+    "body": "table.fill",
+    "prefix": "table.fill"
+  },
+  "table.init": {
+    "body": "table.init",
+    "prefix": "table.init"
+  },
+  "table.copy": {
+    "body": "table.copy",
+    "prefix": "table.copy"
+  },
+  "return_call": {
+    "body": "return_call ",
+    "prefix": "return_call"
+  },
+  "return_call_indirect": {
+    "body": "return_call_indirect ",
+    "prefix": "return_call_indirect"
+  },
+  "exnref": {
+    "body": "exnref",
+    "prefix": "exnref"
+  },
+  "try": {
+    "body": "try",
+    "prefix": "try"
+  },
+  "catch": {
+    "body": "catch",
+    "prefix": "catch"
+  },
+  "throw": {
+    "body": "throw",
+    "prefix": "throw"
+  },
+  "rethrow": {
+    "body": "rethrow",
+    "prefix": "rethrow"
+  },
+  "br_on_exn": {
+    "body": "br_on_exn",
+    "prefix": "br_on_exn"
+  },
+  "i32.push": {
+    "body": "i32.push",
+    "prefix": "i32.push"
+  },
+  "i32.pop": {
+    "body": "i32.pop",
+    "prefix": "i32.pop"
+  },
+  "i64.push": {
+    "body": "i64.push",
+    "prefix": "i64.push"
+  },
+  "i64.pop": {
+    "body": "i64.pop",
+    "prefix": "i64.pop"
+  },
+  "f32.push": {
+    "body": "f32.push",
+    "prefix": "f32.push"
+  },
+  "f32.pop": {
+    "body": "f32.pop",
+    "prefix": "f32.pop"
+  },
+  "f64.push": {
+    "body": "f64.push",
+    "prefix": "f64.push"
+  },
+  "f64.pop": {
+    "body": "f64.pop",
+    "prefix": "f64.pop"
+  },
+  "anyref.push": {
+    "body": "anyref.push",
+    "prefix": "anyref.push"
+  },
+  "anyref.pop": {
+    "body": "anyref.pop",
+    "prefix": "anyref.pop"
+  },
+  "funcref.push": {
+    "body": "funcref.push",
+    "prefix": "funcref.push"
+  },
+  "funcref.pop": {
+    "body": "funcref.pop",
+    "prefix": "funcref.pop"
+  },
+  "nullref.push": {
+    "body": "nullref.push",
+    "prefix": "nullref.push"
+  },
+  "nullref.pop": {
+    "body": "nullref.pop",
+    "prefix": "nullref.pop"
+  },
+  "exnref.push": {
+    "body": "exnref.push",
+    "prefix": "exnref.push"
+  },
+  "exnref.pop": {
+    "body": "exnref.pop",
+    "prefix": "exnref.pop"
+  },
+  "i32": {
+    "body": "i32",
+    "prefix": "i32"
+  },
+  "i64": {
+    "body": "i64",
+    "prefix": "i64"
+  },
+  "f32": {
+    "body": "f32",
+    "prefix": "f32"
+  },
+  "f64": {
+    "body": "f64",
+    "prefix": "f64"
+  },
+  "i32.load": {
+    "body": "i32.load",
+    "prefix": "i32.load"
+  },
+  "i32.load8_s": {
+    "body": "i32.load8_s",
+    "prefix": "i32.load8_s"
+  },
+  "i32.load8_u": {
+    "body": "i32.load8_u",
+    "prefix": "i32.load8_u"
+  },
+  "i32.load16_s": {
+    "body": "i32.load16_s",
+    "prefix": "i32.load16_s"
+  },
+  "i32.load16_u": {
+    "body": "i32.load16_u",
+    "prefix": "i32.load16_u"
+  },
+  "i32.store": {
+    "body": "i32.store",
+    "prefix": "i32.store"
+  },
+  "i32.store8": {
+    "body": "i32.store8",
+    "prefix": "i32.store8"
+  },
+  "i32.store16": {
+    "body": "i32.store16",
+    "prefix": "i32.store16"
+  },
+  "i32.const": {
+    "body": "i32.const ",
+    "prefix": "i32.const"
+  },
+  "i32.eqz": {
+    "body": "i32.eqz",
+    "prefix": "i32.eqz"
+  },
+  "i32.eq": {
+    "body": "i32.eq",
+    "prefix": "i32.eq"
+  },
+  "i32.ne": {
+    "body": "i32.ne",
+    "prefix": "i32.ne"
+  },
+  "i32.lt_s": {
+    "body": "i32.lt_s",
+    "prefix": "i32.lt_s"
+  },
+  "i32.lt_u": {
+    "body": "i32.lt_u",
+    "prefix": "i32.lt_u"
+  },
+  "i32.le_s": {
+    "body": "i32.le_s",
+    "prefix": "i32.le_s"
+  },
+  "i32.le_u": {
+    "body": "i32.le_u",
+    "prefix": "i32.le_u"
+  },
+  "i32.gt_s": {
+    "body": "i32.gt_s",
+    "prefix": "i32.gt_s"
+  },
+  "i32.gt_u": {
+    "body": "i32.gt_u",
+    "prefix": "i32.gt_u"
+  },
+  "i32.ge_s": {
+    "body": "i32.ge_s",
+    "prefix": "i32.ge_s"
+  },
+  "i32.ge_u": {
+    "body": "i32.ge_u",
+    "prefix": "i32.ge_u"
+  },
+  "i32.clz": {
+    "body": "i32.clz",
+    "prefix": "i32.clz"
+  },
+  "i32.ctz": {
+    "body": "i32.ctz",
+    "prefix": "i32.ctz"
+  },
+  "i32.popcnt": {
+    "body": "i32.popcnt",
+    "prefix": "i32.popcnt"
+  },
+  "i32.add": {
+    "body": "i32.add",
+    "prefix": "i32.add"
+  },
+  "i32.sub": {
+    "body": "i32.sub",
+    "prefix": "i32.sub"
+  },
+  "i32.mul": {
+    "body": "i32.mul",
+    "prefix": "i32.mul"
+  },
+  "i32.div_s": {
+    "body": "i32.div_s",
+    "prefix": "i32.div_s"
+  },
+  "i32.div_u": {
+    "body": "i32.div_u",
+    "prefix": "i32.div_u"
+  },
+  "i32.rem_s": {
+    "body": "i32.rem_s",
+    "prefix": "i32.rem_s"
+  },
+  "i32.rem_u": {
+    "body": "i32.rem_u",
+    "prefix": "i32.rem_u"
+  },
+  "i32.and": {
+    "body": "i32.and",
+    "prefix": "i32.and"
+  },
+  "i32.or": {
+    "body": "i32.or",
+    "prefix": "i32.or"
+  },
+  "i32.xor": {
+    "body": "i32.xor",
+    "prefix": "i32.xor"
+  },
+  "i32.shl": {
+    "body": "i32.shl",
+    "prefix": "i32.shl"
+  },
+  "i32.shr_s": {
+    "body": "i32.shr_s",
+    "prefix": "i32.shr_s"
+  },
+  "i32.shr_u": {
+    "body": "i32.shr_u",
+    "prefix": "i32.shr_u"
+  },
+  "i32.rotl": {
+    "body": "i32.rotl",
+    "prefix": "i32.rotl"
+  },
+  "i32.rotr": {
+    "body": "i32.rotr",
+    "prefix": "i32.rotr"
+  },
+  "i32.wrap_i64": {
+    "body": "i32.wrap_i64",
+    "prefix": "i32.wrap_i64"
+  },
+  "i32.trunc_f32_s": {
+    "body": "i32.trunc_f32_s",
+    "prefix": "i32.trunc_f32_s"
+  },
+  "i32.trunc_f32_u": {
+    "body": "i32.trunc_f32_u",
+    "prefix": "i32.trunc_f32_u"
+  },
+  "i32.trunc_f64_s": {
+    "body": "i32.trunc_f64_s",
+    "prefix": "i32.trunc_f64_s"
+  },
+  "i32.trunc_f64_u": {
+    "body": "i32.trunc_f64_u",
+    "prefix": "i32.trunc_f64_u"
+  },
+  "i32.reinterpret_f32": {
+    "body": "i32.reinterpret_f32",
+    "prefix": "i32.reinterpret_f32"
+  },
+  "i64.load": {
+    "body": "i64.load",
+    "prefix": "i64.load"
+  },
+  "i64.load8_s": {
+    "body": "i64.load8_s",
+    "prefix": "i64.load8_s"
+  },
+  "i64.load8_u": {
+    "body": "i64.load8_u",
+    "prefix": "i64.load8_u"
+  },
+  "i64.load16_s": {
+    "body": "i64.load16_s",
+    "prefix": "i64.load16_s"
+  },
+  "i64.load16_u": {
+    "body": "i64.load16_u",
+    "prefix": "i64.load16_u"
+  },
+  "i64.load32_s": {
+    "body": "i64.load32_s",
+    "prefix": "i64.load32_s"
+  },
+  "i64.load32_u": {
+    "body": "i64.load32_u",
+    "prefix": "i64.load32_u"
+  },
+  "i64.store": {
+    "body": "i64.store",
+    "prefix": "i64.store"
+  },
+  "i64.store8": {
+    "body": "i64.store8",
+    "prefix": "i64.store8"
+  },
+  "i64.store16": {
+    "body": "i64.store16",
+    "prefix": "i64.store16"
+  },
+  "i64.store32": {
+    "body": "i64.store32",
+    "prefix": "i64.store32"
+  },
+  "i64.const": {
+    "body": "i64.const ",
+    "prefix": "i64.const"
+  },
+  "i64.eqz": {
+    "body": "i64.eqz",
+    "prefix": "i64.eqz"
+  },
+  "i64.eq": {
+    "body": "i64.eq",
+    "prefix": "i64.eq"
+  },
+  "i64.ne": {
+    "body": "i64.ne",
+    "prefix": "i64.ne"
+  },
+  "i64.lt_s": {
+    "body": "i64.lt_s",
+    "prefix": "i64.lt_s"
+  },
+  "i64.lt_u": {
+    "body": "i64.lt_u",
+    "prefix": "i64.lt_u"
+  },
+  "i64.le_s": {
+    "body": "i64.le_s",
+    "prefix": "i64.le_s"
+  },
+  "i64.le_u": {
+    "body": "i64.le_u",
+    "prefix": "i64.le_u"
+  },
+  "i64.gt_s": {
+    "body": "i64.gt_s",
+    "prefix": "i64.gt_s"
+  },
+  "i64.gt_u": {
+    "body": "i64.gt_u",
+    "prefix": "i64.gt_u"
+  },
+  "i64.ge_s": {
+    "body": "i64.ge_s",
+    "prefix": "i64.ge_s"
+  },
+  "i64.ge_u": {
+    "body": "i64.ge_u",
+    "prefix": "i64.ge_u"
+  },
+  "i64.clz": {
+    "body": "i64.clz",
+    "prefix": "i64.clz"
+  },
+  "i64.ctz": {
+    "body": "i64.ctz",
+    "prefix": "i64.ctz"
+  },
+  "i64.popcnt": {
+    "body": "i64.popcnt",
+    "prefix": "i64.popcnt"
+  },
+  "i64.add": {
+    "body": "i64.add",
+    "prefix": "i64.add"
+  },
+  "i64.sub": {
+    "body": "i64.sub",
+    "prefix": "i64.sub"
+  },
+  "i64.mul": {
+    "body": "i64.mul",
+    "prefix": "i64.mul"
+  },
+  "i64.div_s": {
+    "body": "i64.div_s",
+    "prefix": "i64.div_s"
+  },
+  "i64.div_u": {
+    "body": "i64.div_u",
+    "prefix": "i64.div_u"
+  },
+  "i64.rem_s": {
+    "body": "i64.rem_s",
+    "prefix": "i64.rem_s"
+  },
+  "i64.rem_u": {
+    "body": "i64.rem_u",
+    "prefix": "i64.rem_u"
+  },
+  "i64.and": {
+    "body": "i64.and",
+    "prefix": "i64.and"
+  },
+  "i64.or": {
+    "body": "i64.or",
+    "prefix": "i64.or"
+  },
+  "i64.xor": {
+    "body": "i64.xor",
+    "prefix": "i64.xor"
+  },
+  "i64.shl": {
+    "body": "i64.shl",
+    "prefix": "i64.shl"
+  },
+  "i64.shr_s": {
+    "body": "i64.shr_s",
+    "prefix": "i64.shr_s"
+  },
+  "i64.shr_u": {
+    "body": "i64.shr_u",
+    "prefix": "i64.shr_u"
+  },
+  "i64.rotl": {
+    "body": "i64.rotl",
+    "prefix": "i64.rotl"
+  },
+  "i64.rotr": {
+    "body": "i64.rotr",
+    "prefix": "i64.rotr"
+  },
+  "i64.extend_i32_s": {
+    "body": "i64.extend_i32_s",
+    "prefix": "i64.extend_i32_s"
+  },
+  "i64.extend_i32_u": {
+    "body": "i64.extend_i32_u",
+    "prefix": "i64.extend_i32_u"
+  },
+  "i64.trunc_f32_s": {
+    "body": "i64.trunc_f32_s",
+    "prefix": "i64.trunc_f32_s"
+  },
+  "i64.trunc_f32_u": {
+    "body": "i64.trunc_f32_u",
+    "prefix": "i64.trunc_f32_u"
+  },
+  "i64.trunc_f64_s": {
+    "body": "i64.trunc_f64_s",
+    "prefix": "i64.trunc_f64_s"
+  },
+  "i64.trunc_f64_u": {
+    "body": "i64.trunc_f64_u",
+    "prefix": "i64.trunc_f64_u"
+  },
+  "i64.reinterpret_f64": {
+    "body": "i64.reinterpret_f64",
+    "prefix": "i64.reinterpret_f64"
+  },
+  "f32.load": {
+    "body": "f32.load",
+    "prefix": "f32.load"
+  },
+  "f32.store": {
+    "body": "f32.store",
+    "prefix": "f32.store"
+  },
+  "f32.const": {
+    "body": "f32.const ",
+    "prefix": "f32.const"
+  },
+  "f32.eq": {
+    "body": "f32.eq",
+    "prefix": "f32.eq"
+  },
+  "f32.ne": {
+    "body": "f32.ne",
+    "prefix": "f32.ne"
+  },
+  "f32.lt": {
+    "body": "f32.lt",
+    "prefix": "f32.lt"
+  },
+  "f32.le": {
+    "body": "f32.le",
+    "prefix": "f32.le"
+  },
+  "f32.gt": {
+    "body": "f32.gt",
+    "prefix": "f32.gt"
+  },
+  "f32.ge": {
+    "body": "f32.ge",
+    "prefix": "f32.ge"
+  },
+  "f32.abs": {
+    "body": "f32.abs",
+    "prefix": "f32.abs"
+  },
+  "f32.neg": {
+    "body": "f32.neg",
+    "prefix": "f32.neg"
+  },
+  "f32.ceil": {
+    "body": "f32.ceil",
+    "prefix": "f32.ceil"
+  },
+  "f32.floor": {
+    "body": "f32.floor",
+    "prefix": "f32.floor"
+  },
+  "f32.trunc": {
+    "body": "f32.trunc",
+    "prefix": "f32.trunc"
+  },
+  "f32.nearest": {
+    "body": "f32.nearest",
+    "prefix": "f32.nearest"
+  },
+  "f32.sqrt": {
+    "body": "f32.sqrt",
+    "prefix": "f32.sqrt"
+  },
+  "f32.add": {
+    "body": "f32.add",
+    "prefix": "f32.add"
+  },
+  "f32.sub": {
+    "body": "f32.sub",
+    "prefix": "f32.sub"
+  },
+  "f32.mul": {
+    "body": "f32.mul",
+    "prefix": "f32.mul"
+  },
+  "f32.div": {
+    "body": "f32.div",
+    "prefix": "f32.div"
+  },
+  "f32.min": {
+    "body": "f32.min",
+    "prefix": "f32.min"
+  },
+  "f32.max": {
+    "body": "f32.max",
+    "prefix": "f32.max"
+  },
+  "f32.copysign": {
+    "body": "f32.copysign",
+    "prefix": "f32.copysign"
+  },
+  "f32.convert_i32_s": {
+    "body": "f32.convert_i32_s",
+    "prefix": "f32.convert_i32_s"
+  },
+  "f32.convert_i32_u": {
+    "body": "f32.convert_i32_u",
+    "prefix": "f32.convert_i32_u"
+  },
+  "f32.convert_i64_s": {
+    "body": "f32.convert_i64_s",
+    "prefix": "f32.convert_i64_s"
+  },
+  "f32.convert_i64_u": {
+    "body": "f32.convert_i64_u",
+    "prefix": "f32.convert_i64_u"
+  },
+  "f32.demote_f64": {
+    "body": "f32.demote_f64",
+    "prefix": "f32.demote_f64"
+  },
+  "f32.reinterpret_i32": {
+    "body": "f32.reinterpret_i32",
+    "prefix": "f32.reinterpret_i32"
+  },
+  "f64.load": {
+    "body": "f64.load",
+    "prefix": "f64.load"
+  },
+  "f64.store": {
+    "body": "f64.store",
+    "prefix": "f64.store"
+  },
+  "f64.const": {
+    "body": "f64.const ",
+    "prefix": "f64.const"
+  },
+  "f64.eq": {
+    "body": "f64.eq",
+    "prefix": "f64.eq"
+  },
+  "f64.ne": {
+    "body": "f64.ne",
+    "prefix": "f64.ne"
+  },
+  "f64.lt": {
+    "body": "f64.lt",
+    "prefix": "f64.lt"
+  },
+  "f64.le": {
+    "body": "f64.le",
+    "prefix": "f64.le"
+  },
+  "f64.gt": {
+    "body": "f64.gt",
+    "prefix": "f64.gt"
+  },
+  "f64.ge": {
+    "body": "f64.ge",
+    "prefix": "f64.ge"
+  },
+  "f64.abs": {
+    "body": "f64.abs",
+    "prefix": "f64.abs"
+  },
+  "f64.neg": {
+    "body": "f64.neg",
+    "prefix": "f64.neg"
+  },
+  "f64.ceil": {
+    "body": "f64.ceil",
+    "prefix": "f64.ceil"
+  },
+  "f64.floor": {
+    "body": "f64.floor",
+    "prefix": "f64.floor"
+  },
+  "f64.trunc": {
+    "body": "f64.trunc",
+    "prefix": "f64.trunc"
+  },
+  "f64.nearest": {
+    "body": "f64.nearest",
+    "prefix": "f64.nearest"
+  },
+  "f64.sqrt": {
+    "body": "f64.sqrt",
+    "prefix": "f64.sqrt"
+  },
+  "f64.add": {
+    "body": "f64.add",
+    "prefix": "f64.add"
+  },
+  "f64.sub": {
+    "body": "f64.sub",
+    "prefix": "f64.sub"
+  },
+  "f64.mul": {
+    "body": "f64.mul",
+    "prefix": "f64.mul"
+  },
+  "f64.div": {
+    "body": "f64.div",
+    "prefix": "f64.div"
+  },
+  "f64.min": {
+    "body": "f64.min",
+    "prefix": "f64.min"
+  },
+  "f64.max": {
+    "body": "f64.max",
+    "prefix": "f64.max"
+  },
+  "f64.copysign": {
+    "body": "f64.copysign",
+    "prefix": "f64.copysign"
+  },
+  "f64.convert_i32_s": {
+    "body": "f64.convert_i32_s",
+    "prefix": "f64.convert_i32_s"
+  },
+  "f64.convert_i32_u": {
+    "body": "f64.convert_i32_u",
+    "prefix": "f64.convert_i32_u"
+  },
+  "f64.convert_i64_s": {
+    "body": "f64.convert_i64_s",
+    "prefix": "f64.convert_i64_s"
+  },
+  "f64.convert_i64_u": {
+    "body": "f64.convert_i64_u",
+    "prefix": "f64.convert_i64_u"
+  },
+  "f64.promote_f32": {
+    "body": "f64.promote_f32",
+    "prefix": "f64.promote_f32"
+  },
+  "f64.reinterpret_i64": {
+    "body": "f64.reinterpret_i64",
+    "prefix": "f64.reinterpret_i64"
+  },
+  "memory.size": {
+    "body": "memory.size",
+    "prefix": "memory.size"
+  },
+  "memory.grow": {
+    "body": "memory.grow",
+    "prefix": "memory.grow"
+  },
+  "local.get": {
+    "body": "local.get ",
+    "prefix": "local.get"
+  },
+  "local.set": {
+    "body": "local.set ",
+    "prefix": "local.set"
+  },
+  "local.tee": {
+    "body": "local.tee ",
+    "prefix": "local.tee"
+  },
+  "global.get": {
+    "body": "global.get ",
+    "prefix": "global.get"
+  },
+  "global.set": {
+    "body": "global.set ",
+    "prefix": "global.set"
+  },
+  "unreachable": {
+    "body": "unreachable",
+    "prefix": "unreachable"
+  },
+  "nop": {
+    "body": "nop",
+    "prefix": "nop"
+  },
+  "block": {
+    "body": "block",
+    "prefix": "block"
+  },
+  "loop": {
+    "body": "loop",
+    "prefix": "loop"
+  },
+  "if": {
+    "body": "if",
+    "prefix": "if"
+  },
+  "else": {
+    "body": "else",
+    "prefix": "else"
+  },
+  "end": {
+    "body": "end",
+    "prefix": "end"
+  },
+  "br": {
+    "body": "br ",
+    "prefix": "br"
+  },
+  "br_if": {
+    "body": "br_if ",
+    "prefix": "br_if"
+  },
+  "br_table": {
+    "body": "br_table ",
+    "prefix": "br_table"
+  },
+  "return": {
+    "body": "return",
+    "prefix": "return"
+  },
+  "call": {
+    "body": "call ",
+    "prefix": "call"
+  },
+  "call_indirect": {
+    "body": "call_indirect ",
+    "prefix": "call_indirect"
+  },
+  "drop": {
+    "body": "drop",
+    "prefix": "drop"
+  },
+  "select": {
+    "body": "select",
+    "prefix": "select"
+  }    
 }

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -1,0 +1,19 @@
+This grammar covers the instructions of the following standards respectively proposals (Jan. 2020):
+
+* [MVP](https://webassembly.github.io/spec/core/text/index.html)
+* [Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
+* [Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)
+* [Bulk memory operations](https://github.com/WebAssembly/bulk-memory-operations)
+* [Fixed-width SIMD](https://github.com/WebAssembly/simd)
+* [Threads](https://github.com/WebAssembly/threads)
+* [Reference types](https://github.com/WebAssembly/reference-types)
+* [Tail Call](https://github.com/WebAssembly/tail-call)
+* [Exception handling](https://github.com/WebAssembly/exception-handling)
+
+Plus a few non-standard extensions not actually part of the language, but used in intermediate files produced by popular tooling:
+
+* [Binaryen extensions](https://github.com/WebAssembly/binaryen) (pseudo `.push`/`.pop`)
+
+Pattern names as of [Sublime Text / Scope Naming](https://www.sublimetext.com/docs/3/scope_naming.html).
+
+TODO: The grammar does not (yet) attempt to recognize individual contents of the various sections. So far, most patterns are applied globally.

--- a/syntaxes/wat.json
+++ b/syntaxes/wat.json
@@ -574,8 +574,12 @@
           "patterns": [
             {
               "comment": "Passive modifier [bulk-memory-operations]",
-              "name": "storage.modifier.wat",
-              "match": "(?<=\\(data )\\bpassive\\b"
+              "match": "(?<=\\(data)\\s+(passive)\\b",
+              "captures": {
+                "1": {
+                  "name": "storage.modifier.wat"
+                }
+              }
             }
           ]
         },
@@ -585,17 +589,26 @@
             {
               "comment": "Module element [mvp]",
               "name": "storage.type.wat",
-              "match": "(?<=\\()\\b(?:module|import|export|memory|data|table|elem|start|func|type|param|result|global|local)\\b"
+              "match": "(?<=\\()(?:module|import|export|memory|data|table|elem|start|func|type|param|result|global|local)\\b"
             },
             {
               "comment": "Mutable global modifier [mvp]",
               "name": "storage.modifier.wat",
-              "match": "(?<=\\()\\bmut\\b"
+              "match": "(?<=\\()\\s*(mut)\\b",
+              "captures": {
+                "1": {
+                  "name": "storage.modifier.wat"
+                }
+              }
             },
             {
               "comment": "Function name [mvp]",
-              "name": "entity.name.function.wat",
-              "match": "(?<=\\(func\\s|\\(start\\s|call |return_call |ref\\.func )\\s*\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+              "match": "(?<=\\(func|\\(start|call|return_call|ref\\.func)\\s+(\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.function.wat"
+                }
+              }
             },
             {
               "comment": "Function name(s) (elem) [mvp]",
@@ -609,14 +622,18 @@
               "patterns": [
                 {
                   "name": "entity.name.function.wat",
-                  "match": "\\s+\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+                  "match": "(?<=\\s)\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
                 }
               ]
             },
             {
               "comment": "Function type [mvp]",
-              "name": "support.type.function.wat",
-              "match": "(?<=\\(type\\s)\\s*\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+              "match": "(?<=\\(type)\\s+(\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*)",
+              "captures": {
+                "1": {
+                  "name": "support.type.function.wat"
+                }
+              }
             },
             {
               "comment": "Variable name or branch label [mvp]",

--- a/syntaxes/webassembly.tmLanguage.json
+++ b/syntaxes/webassembly.tmLanguage.json
@@ -1,227 +1,703 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "WebAssembly",
-	"patterns": [
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#types"
-		},
-		{
-			"include": "#section"
-		},
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#numeric"
-		},
-		{
-			"include": "#linear-memory-accesses"
-		},
-		{
-			"include": "#resizing"
-		},
-		{
-			"include": "#calls"
-		},
-		{
-			"include": "#variables"
-		},
-		{
-			"include": "#control"
-		},
-		{
-			"include": "#integer-operators"
-		}
-	],
-	"repository": {
-		"keywords": {
-			"patterns": [
-				{
-					"name": "storage.type.wasm",
-					"match": "\\b(func|type|param|result)\\b"
-				},
-				{
-					"name": "storage.modifier.wasm",
-					"match": "\\b(mut)\\b"
-				},
-				{
-					"name": "variable.parameter.other.wasm",
-					"match": "(\\$){1}([\\w\\d]*)"
-				}
-			]
-		},
-		"numeric": {
-			"patterns": [
-				{
-					"name": "constant.numeric.wasm",
-					"match": "-?(0x[0-9a-fA-F][0-9a-fA-F_]*|\\d[\\d_]*)"
-				}
-			]
-		},
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.character.wasm",
-					"match": "(;{2})(.*)$"
-				},
-				{
-					"name": "comment.block.wasm",
-					"begin": "\\(;",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.wasm"
-						}
-					},
-					"end": ";\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.wasm"
-						}
-					}
-				}
-			]
-		},
-		"section": {
-			"patterns": [
-				{
-					"name": "storage.type.wasm",
-					"match": "\\b(module|import|export|memory|table|start|elem|data|local|global)\\b"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.wasm",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.wasm",
-					"match": "\\\\(n|t|\\\\|'|\"|[0-9a-fA-F]{2})"
-				}
-			]
-		},
-		"types": {
-			"patterns": [
-				{
-					"name": "entity.name.type.wasm",
-					"match": "(i32|i64|f32|f64|anyfunc|v128)"
-				}
-			]
-		},
-		"linear-memory-accesses": {
-			"patterns": [
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(store|store8|store16|store32)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(load|load8_s|load16_s|load32_s|load8_u|load16_u|load32_u)\\b"
-				}
-			]
-		},
-		"resizing": {
-			"patterns": [
-				{
-					"name": "support.function.wasm",
-					"match": "\\b(grow_memory|current_memory)\\b"
-				}
-			]
-		},
-		"calls": {
-			"patterns": [
-				{
-					"name": "support.function.wasm",
-					"match": "\\b(call|call_indirect)\\b"
-				}
-			]
-		},
-		"variables": {
-			"patterns": [
-				{
-					"name": "keyword.other.wasm",
-					"match": "\\b(get_local|get_global|set_local|set_global|tee_local)\\b"
-				}
-			]
-		},
-		"control": {
-			"patterns": [
-				{
-					"name": "keyword.control.wasm",
-					"match": "\\b(nop|block|loop|if|then|else|br|br_if|br_table|end|return|drop|select|unreachable)\\b"
-				}
-			]
-		},
-		"integer-operators": {
-			"patterns": [
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b((div|gt|ge|lt|le)(_(s|u))?)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b((shr|rem)_(s|u))\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(const|add|sub|mul|abs|neg|ceil|floor|trunc|copysign|ceil|nearest|min|max|sqrt|and|or|xor|shl|rotl|rotr|eq|ne|clz|ctz|popcnt|eqz)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(wrap/i64|demote/f64|promote/f32)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(reinterpret/(i32|f32|i64|f64))\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(trunc_(s|u)/(f32|f64))\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(extend_(s|u)/i32)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(convert_(s|u)/(i32|i64))\\b"
-				}
-			]
-		},
-		"SIMD": {
-			"patterns": [
-				{
-					"name": "entity.name.type.wasm",
-					"match": "(i8x16|i16x8|i32x4|i64x2|f32x4|f64x2)"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(convert_(s|u)/(i32x4|i64x2))\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(trunc_(s|u)/(f32x4|f64x2):sat)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b((extract_lane)(_(s|u))?)\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b((add_saturate|sub_saturate)(_(s|u)))\\b"
-				},
-				{
-					"name": "entity.name.function.wasm",
-					"match": "\\b(splat|replace_lane|bitselect|any_true|shuffle)\\b"
-				}
-			]
-		}
-	},
-	"scopeName": "source.wasm"
+  "name": "WebAssembly Text Format",
+  "scopeName": "source.wat",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#instructions"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#modules"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#invalid"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "comment": "Line comment",
+          "name": "comment.line.wat",
+          "match": "(;;).*$",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.wat"
+            }
+          }
+        },
+        {
+          "comment": "Block comment",
+          "name": "comment.block.wat",
+          "begin": "\\(;",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.wat"
+            }
+          },
+          "end": ";\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.wat"
+            }
+          }
+        }
+      ]
+    },
+    "strings": {
+      "comment": "String literal",
+      "name": "string.quoted.double.wat",
+      "begin": "\"",
+      "end": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end"
+        }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.wat",
+          "match": "\\\\(n|t|\\\\|'|\"|[0-9a-fA-F]{2})"
+        }
+      ]
+    },
+    "instructions": {
+      "patterns": [
+        {
+          "comment": "Non-trapping float-to-int conversions",
+          "patterns": [
+            {
+              "comment": "Conversion instruction [nontrapping-float-to-int-conversions]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32|i64)\\.trunc_sat_f(?:32|64)_[su]\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Sign-extension operators",
+          "patterns": [
+            {
+              "comment": "Numeric instruction (i32) [sign-extension-ops]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32)\\.(?:extend(?:8|16)_s)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Numeric instruction (i64) [sign-extension-ops]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i64)\\.(?:extend(?:8|16|32)_s)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Bulk memory operations",
+          "patterns": [
+            {
+              "comment": "Memory instruction [bulk-memory-operations]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(memory)\\.(?:copy|fill|init|drop)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Fixed-width SIMD",
+          "patterns": [
+            {
+              "comment": "Vector instruction (v128) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(v128)\\.(?:const|and|or|xor|not|andnot|bitselect|load|store)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (i8x16) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i8x16)\\.(?:splat|replace_lane|add|sub|mul|neg|shl|shr_[su]|eq|ne|lt_[su]|le_[su]|gt_[su]|ge_[su]|min_[su]|max_[su]|any_true|all_true|extract_lane_[su]|add_saturate_[su]|sub_saturate_[su]|avgr_u|narrow_i16x8_[su])\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (i16x8) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i16x8)\\.(?:splat|replace_lane|add|sub|mul|neg|shl|shr_[su]|eq|ne|lt_[su]|le_[su]|gt_[su]|ge_[su]|min_[su]|max_[su]|any_true|all_true|extract_lane_[su]|add_saturate_[su]|sub_saturate_[su]|avgr_u|load8x8_[su]|narrow_i32x4_[su]|widen_(low|high)_i8x16_[su])\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (i32x4) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32x4)\\.(?:splat|replace_lane|add|sub|mul|neg|shl|shr_[su]|eq|ne|lt_[su]|le_[su]|gt_[su]|ge_[su]|min_[su]|max_[su]|any_true|all_true|extract_lane|load16x4_[su]|trunc_sat_f32x4_[su]|widen_(low|high)_i16x8_[su])\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (i64x2) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i64x2)\\.(?:splat|replace_lane|add|sub|mul|neg|shl|shr_[su]|extract_lane|load32x2_[su])\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (f32x4) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f32x4)\\.(?:splat|replace_lane|add|sub|mul|neg|extract_lane|eq|ne|lt|le|gt|ge|abs|min|max|div|sqrt|convert_i32x4_[su])\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (f64x2) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f64x2)\\.(?:splat|replace_lane|add|sub|mul|neg|extract_lane|eq|ne|lt|le|gt|ge|abs|min|max|div|sqrt)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (v8x16) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(v8x16)\\.(?:load_splat|shuffle|swizzle)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (v16x8) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(v16x8)\\.load_splat\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (v32x4) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(v32x4)\\.load_splat\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector instruction (v64x2) [simd]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(v64x2)\\.load_splat\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Threads",
+          "patterns": [
+            {
+              "comment": "Atomic instruction (i32) [threads]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32)\\.(atomic)\\.(?:load(?:8_u|16_u)?|store(?:8|16)?|wait|(rmw)\\.(?:add|sub|and|or|xor|xchg|cmpxchg)|(rmw8|rmw16)\\.(?:add_u|sub_u|and_u|or_u|xor_u|xchg_u|cmpxchg_u))\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                },
+                "2": {
+                  "name": "support.class.wat"
+                },
+                "3": {
+                  "name": "support.class.wat"
+                },
+                "4": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Atomic instruction (i64) [threads]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i64)\\.(atomic)\\.(?:load(?:8_u|16_u|32_u)?|store(?:8|16|32)?|wait|(rmw)\\.(?:add|sub|and|or|xor|xchg|cmpxchg)|(rmw8|rmw16|rmw32)\\.(?:add_u|sub_u|and_u|or_u|xor_u|xchg_u|cmpxchg_u))\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                },
+                "2": {
+                  "name": "support.class.wat"
+                },
+                "3": {
+                  "name": "support.class.wat"
+                },
+                "4": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Atomic instruction [threads]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(atomic)\\.(?:notify|fence)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Shared modifier [threads]",
+              "name": "storage.modifier.wat",
+              "match": "\\bshared\\b"
+            }
+          ]
+        },
+        {
+          "comment": "Reference types",
+          "patterns": [
+            {
+              "comment": "Reference instruction [reference-types]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(ref)\\.(?:null|is_null|func)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Table instruction [reference-types]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(table)\\.(?:get|size|grow|fill|init|copy)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Type name [reference-types]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:anyref|funcref|nullref)\\b"
+            }
+          ]
+        },
+        {
+          "comment": "Tail Call",
+          "patterns": [
+            {
+              "comment": "Control instruction [tail-call]",
+              "name": "keyword.control.wat",
+              "match": "\\breturn_call(?:_indirect)?\\b"
+            }
+          ]
+        },
+        {
+          "comment": "Exception handling",
+          "patterns": [
+            {
+              "comment": "Control instruction [exception-handling]",
+              "name": "keyword.control.wat",
+              "match": "\\b(?:try|catch|throw|rethrow|br_on_exn)\\b"
+            },
+            {
+              "comment": "Module element [exception-handling]",
+              "name": "storage.type.wat",
+              "match": "(?<=\\()event\\b"
+            }
+          ]
+        },
+        {
+          "comment": "Binaryen extensions",
+          "patterns": [
+            {
+              "comment": "Pseudo stack instruction [binaryen]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32|i64|f32|f64|anyref|funcref|nullref|exnref)\\.(?:push|pop)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "MVP",
+          "patterns": [
+            {
+              "comment": "Memory instruction (i32) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32)\\.(?:load|load(?:8|16)(?:_[su])?|store(?:8|16)?)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Memory instruction (i64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i64)\\.(?:load|load(?:8|16|32)(?:_[su])?|store(?:8|16|32)?)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Memory instruction (f32/f64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f32|f64)\\.(?:load|store)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Memory instruction [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(memory)\\.(?:size|grow)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.memory.wat"
+                }
+              }
+            },
+            {
+              "comment": "Memory instruction attribute [mvp]",
+              "match": "\\b(offset|align)=\\b",
+              "captures": {
+                "1": {
+                  "name": "entity.other.attribute-name.wat"
+                }
+              }
+            },
+            {
+              "comment": "Variable instruction (local) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(local)\\.(?:get|set|tee)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.local.wat"
+                }
+              }
+            },
+            {
+              "comment": "Variable instruction (global) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(global)\\.(?:get|set)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.global.wat"
+                }
+              }
+            },
+            {
+              "comment": "Numeric instruction (i32/i64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32|i64)\\.(const|eqz|eq|ne|lt_[su]|gt_[su]|le_[su]|ge_[su]|clz|ctz|popcnt|add|sub|mul|div_[su]|rem_[su]|and|or|xor|shl|shr_[su]|rotl|rotr)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Numeric instruction (f32/f64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f32|f64)\\.(const|eq|ne|lt|gt|le|ge|abs|neg|ceil|floor|trunc|nearest|sqrt|add|sub|mul|div|min|max|copysign)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Conversion instruction (i32) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i32)\\.(wrap_i64|trunc_(f32|f64)_[su]|reinterpret_f32)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Conversion instruction (i64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i64)\\.(extend_i32_[su]|trunc_f(32|64)_[su]|reinterpret_f64)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Conversion instruction (f32) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f32)\\.(convert_i(32|64)_[su]|demote_f64|reinterpret_i32)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Conversion instruction (f64) [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(f64)\\.(convert_i(32|64)_[su]|promote_f32|reinterpret_i64)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Control instruction [mvp]",
+              "name": "keyword.control.wat",
+              "match": "\\b(?:unreachable|nop|block|loop|if|else|end|br|br_if|br_table|return|call|call_indirect)\\b"
+            },
+            {
+              "comment": "Parametric instruction [mvp]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(?:drop|select)\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "comment": "Fixed-width SIMD",
+          "patterns": [
+            {
+              "comment": "Type name [simd]",
+              "name": "entity.name.type.wat",
+              "match": "\\bv128\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "Reference types",
+          "patterns": [
+            {
+              "comment": "Type name [reference-types]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:anyref|funcref|nullref)\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "Exception handling",
+          "patterns": [
+            {
+              "comment": "Type name [exception-handling]",
+              "name": "entity.name.type.wat",
+              "match": "\\bexnref\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "MVP",
+          "patterns": [
+            {
+              "comment": "Type name [mvp]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:i32|i64|f32|f64)\\b(?!\\.)"
+            }
+          ]
+        }
+      ]
+    },
+    "modules": {
+      "patterns": [
+        {
+          "comment": "Bulk memory operations",
+          "patterns": [
+            {
+              "comment": "Passive modifier [bulk-memory-operations]",
+              "name": "storage.modifier.wat",
+              "match": "(?<=\\(data )\\bpassive\\b"
+            }
+          ]
+        },
+        {
+          "comment": "MVP",
+          "patterns":	[
+            {
+              "comment": "Module element [mvp]",
+              "name": "storage.type.wat",
+              "match": "(?<=\\()\\b(?:module|import|export|memory|data|table|elem|start|func|type|param|result|global|local)\\b"
+            },
+            {
+              "comment": "Mutable global modifier [mvp]",
+              "name": "storage.modifier.wat",
+              "match": "(?<=\\()\\bmut\\b"
+            },
+            {
+              "comment": "Function name [mvp]",
+              "name": "entity.name.function.wat",
+              "match": "(?<=\\(func\\s|\\(start\\s|call |return_call |ref\\.func )\\s*\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+            },
+            {
+              "comment": "Function name(s) (elem) [mvp]",
+              "begin": "\\)\\s+(\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*)",
+              "beginCaptures": {
+                "1": {
+                  "name": "entity.name.function.wat"
+                }
+              },
+              "end": "\\)",
+              "patterns": [
+                {
+                  "name": "entity.name.function.wat",
+                  "match": "\\s+\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+                }
+              ]
+            },
+            {
+              "comment": "Function type [mvp]",
+              "name": "support.type.function.wat",
+              "match": "(?<=\\(type\\s)\\s*\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
+            },
+            {
+              "comment": "Variable name or branch label [mvp]",
+              "name": "variable.other.wat",
+              "match": "\\$[0-9A-Za-z!#$%&'*+\\-./:<=>?@\\\\^_`|~]*\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "comment": "Fixed-width SIMD",
+          "patterns": [
+            {
+              "comment": "Vector literal (i8x16) [simd]",
+              "name": "constant.numeric.vector.wat",
+              "match": "\\b(i8x16)(?:\\s+0x[0-9a-fA-F]{1,2}){16}\\b",
+              "captures": {
+                "1": {
+                  "name": "support.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector literal (i16x8) [simd]",
+              "name": "constant.numeric.vector.wat",
+              "match": "\\b(i16x8)(?:\\s+0x[0-9a-fA-F]{1,4}){8}\\b",
+              "captures": {
+                "1": {
+                  "name": "support.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector literal (i32x4) [simd]",
+              "name": "constant.numeric.vector.wat",
+              "match": "\\b(i32x4)(?:\\s+0x[0-9a-fA-F]{1,8}){4}\\b",
+              "captures": {
+                "1": {
+                  "name": "support.type.wat"
+                }
+              }
+            },
+            {
+              "comment": "Vector literal (i64x2) [simd]",
+              "name": "constant.numeric.vector.wat",
+              "match": "\\b(i64x2)(?:\\s+0x[0-9a-fA-F]{1,16}){2}\\b",
+              "captures": {
+                "1": {
+                  "name": "support.type.wat"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "MVP",
+          "patterns": [
+            {
+              "comment": "Floating point literal",
+              "name": "constant.numeric.float.wat",
+              "match": "\\b[0-9][0-9]*(?:\\.[0-9][0-9]*)?(?:[eE][+-]?[0-9]+)?\\b"
+            },
+            {
+              "comment": "Integer literal",
+              "name": "constant.numeric.integer.wat",
+              "match": "-?\\b(?:0x[0-9a-fA-F][0-9a-fA-F]*|\\d[\\d]*)\\b"
+            }	
+          ]
+        }
+      ]
+    },
+    "invalid": {
+      "patterns": [
+        {
+          "name": "invalid.wat",
+          "match": "[^\\s()]+"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
* Remove no longer valid instructions
* Support all current instructions, incl. experimental ones in the wild
* Support non-standard Binaryen extensions in its s-expr format
* Recognize ids as of the spec
* Recognize ids referring to a function name
* Add floating point literals
* Fix whitespace
* Fix snippet warnings

Still not perfect and probably the most horrible PR diff I've proposed in a while. Would totally understand if that's not a PR you are comfortable with, yet didn't know what else to do with all of this.

Is this something you'd consider?