### PR TITLE
Add highlighting of nan literals

### DIFF
--- a/syntaxes/wat.json
+++ b/syntaxes/wat.json
@@ -700,10 +700,15 @@
               "match": "\\b[0-9][0-9]*(?:\\.[0-9][0-9]*)?(?:[eE][+-]?[0-9]+)?\\b"
             },
             {
+              "comment": "Floating point literal (NaN)",
+              "name": "constant.numeric.float.wat",
+              "match": "\\bnan:0x[0-9a-fA-F][0-9a-fA-F]*\\b"
+            },
+            {
               "comment": "Integer literal",
               "name": "constant.numeric.integer.wat",
               "match": "-?\\b(?:0x[0-9a-fA-F][0-9a-fA-F]*|\\d[\\d]*)\\b"
-            }	
+            }
           ]
         }
       ]


### PR DESCRIPTION
This is a special case of floating point literals, specifying the exact bit pattern of a NaN.