### PR TITLE
GC MVP Instructions and Types

### DIFF
--- a/snippets/instructions.json
+++ b/snippets/instructions.json
@@ -2134,5 +2134,113 @@
   "select": {
     "body": "select",
     "prefix": "select"
+  },
+  "ref.eq": {
+    "body": "ref.eq",
+    "prefix": "ref.eq"
+  },
+  "ref.test": {
+    "body": "ref.test",
+    "prefix": "ref.test"
+  },
+  "ref.cast": {
+    "body": "ref.cast",
+    "prefix": "ref.cast"
+  },
+  "br_on_non_null": {
+    "body": "br_on_non_null ",
+    "prefix": "br_on_non_null"
+  },
+  "br_on_cast": {
+    "body": "br_on_cast ",
+    "prefix": "br_on_cast"
+  },
+  "br_on_cast_fail": {
+    "body": "br_on_cast_fail ",
+    "prefix": "br_on_cast_fail"
+  },
+  "struct.new_canon": {
+    "body": "struct.new_canon ",
+    "prefix": "struct.new_canon"
+  },
+  "struct.new_canon_default": {
+    "body": "struct.new_canon_default ",
+    "prefix": "struct.new_canon_default"
+  },
+  "struct.get": {
+    "body": "struct.get ",
+    "prefix": "struct.get"
+  },
+  "struct.get_s": {
+    "body": "struct.get_s ",
+    "prefix": "struct.get_s"
+  },
+  "struct.get_u": {
+    "body": "struct.get_u ",
+    "prefix": "struct.get_u"
+  },
+  "struct.set": {
+    "body": "struct.set ",
+    "prefix": "struct.set"
+  },
+  "array.new_canon": {
+    "body": "array.new_canon ",
+    "prefix": "array.new_canon"
+  },
+  "array.new_canon_default": {
+    "body": "array.new_canon_default ",
+    "prefix": "array.new_canon_default"
+  },
+  "array.get": {
+    "body": "array.get ",
+    "prefix": "array.get"
+  },
+  "array.get_s": {
+    "body": "array.get_s ",
+    "prefix": "array.get_s"
+  },
+  "array.get_u": {
+    "body": "array.get_u ",
+    "prefix": "array.get_u"
+  },
+  "array.set": {
+    "body": "array.set ",
+    "prefix": "array.set"
+  },
+  "array.len": {
+    "body": "array.len",
+    "prefix": "array.len"
+  },
+  "array.new_canon_fixed": {
+    "body": "array.new_canon_fixed ",
+    "prefix": "array.new_canon_fixed"
+  },
+  "array.new_canon_data": {
+    "body": "array.new_canon_data ",
+    "prefix": "array.new_canon_data"
+  },
+  "array.new_canon_elem": {
+    "body": "array.new_canon_elem ",
+    "prefix": "array.new_canon_elem"
+  },
+  "i31.new": {
+    "body": "i31.new",
+    "prefix": "i31.new"
+  },
+  "i31.get_s": {
+    "body": "i31.get_s",
+    "prefix": "i31.get_s"
+  },
+  "i31.get_u": {
+    "body": "i31.get_u",
+    "prefix": "i31.get_u"
+  },
+  "extern.internalize": {
+    "body": "extern.internalize",
+    "prefix": "extern.internalize"
+  },
+  "extern.externalize": {
+    "body": "extern.externalize",
+    "prefix": "extern.externalize"
   }
 }

--- a/snippets/types.json
+++ b/snippets/types.json
@@ -130,5 +130,9 @@
   "field": {
     "body": "field",
     "prefix": "field"
+  },
+  "ref": {
+    "body": "ref",
+    "prefix": "ref"
   }
 }

--- a/snippets/types.json
+++ b/snippets/types.json
@@ -34,5 +34,101 @@
   "exnref": {
     "body": "exnref",
     "prefix": "exnref"
+  },
+  "i8": {
+    "body": "i8",
+    "prefix": "i8"
+  },
+  "i16": {
+    "body": "i16",
+    "prefix": "i16"
+  },
+  "anyref": {
+    "body": "anyref",
+    "prefix": "anyref"
+  },
+  "eqref": {
+    "body": "eqref",
+    "prefix": "eqref"
+  },
+  "i31ref": {
+    "body": "i31ref",
+    "prefix": "i31ref"
+  },
+  "nullfuncref": {
+    "body": "nullfuncref",
+    "prefix": "nullfuncref"
+  },
+  "nullexternref": {
+    "body": "nullexternref",
+    "prefix": "nullexternref"
+  },
+  "structref": {
+    "body": "structref",
+    "prefix": "structref"
+  },
+  "arrayref": {
+    "body": "arrayref",
+    "prefix": "arrayref"
+  },
+  "type": {
+    "body": "type",
+    "prefix": "type"
+  },
+  "func": {
+    "body": "func",
+    "prefix": "func"
+  },
+  "extern": {
+    "body": "extern",
+    "prefix": "extern"
+  },
+  "any": {
+    "body": "any",
+    "prefix": "any"
+  },
+  "eq": {
+    "body": "eq",
+    "prefix": "eq"
+  },
+  "i31": {
+    "body": "i31",
+    "prefix": "i31"
+  },
+  "nofunc": {
+    "body": "nofunc",
+    "prefix": "nofunc"
+  },
+  "noextern": {
+    "body": "noextern",
+    "prefix": "noextern"
+  },
+  "struct": {
+    "body": "struct",
+    "prefix": "struct"
+  },
+  "array": {
+    "body": "array",
+    "prefix": "array"
+  },
+  "none": {
+    "body": "none",
+    "prefix": "none"
+  },
+  "sub": {
+    "body": "sub",
+    "prefix": "sub"
+  },
+  "final": {
+    "body": "final",
+    "prefix": "final"
+  },
+  "rec": {
+    "body": "rec",
+    "prefix": "rec"
+  },
+  "field": {
+    "body": "field",
+    "prefix": "field"
   }
 }

--- a/syntaxes/wat.json
+++ b/syntaxes/wat.json
@@ -636,7 +636,7 @@
             {
               "comment": "Type name [GC]",
               "name": "entity.name.type.wat",
-              "match": "\\b(?:i8|i16|funcref|externref|anyref|eqref|i31ref|nullfuncref|nullexternref|structref|arrayref|nullref)\\b(?!\\.)"
+              "match": "\\b(?:i8|i16|ref|funcref|externref|anyref|eqref|i31ref|nullfuncref|nullexternref|structref|arrayref|nullref)\\b(?!\\.)"
             }
           ]
         },

--- a/syntaxes/wat.json
+++ b/syntaxes/wat.json
@@ -520,6 +520,71 @@
               "match": "\\b(?:drop|select)\\b"
             }
           ]
+        },
+        {
+          "comment": "GC Instructions",
+          "patterns": [
+            {
+              "comment": "Reference Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(ref)\\.(?:eq|test|cast)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Struct Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(struct)\\.(?:new_canon|new_canon_default|get|get_s|get_u|set)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Array Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(array)\\.(?:new_canon|new_canon_default|get|get_s|get_u|set|len|new_canon_fixed|new_canon_data|new_canon_elem)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "i31 Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(i31)\\.(?:new|get_s|get_u)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Branch Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(?:br_on_non_null|br_on_cast|br_on_cast_fail)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            },
+            {
+              "comment": "Reference Instructions [GC]",
+              "name": "keyword.operator.word.wat",
+              "match": "\\b(extern)\\.(?:internalize|externalize)\\b",
+              "captures": {
+                "1": {
+                  "name": "support.class.wat"
+                }
+              }
+            }
+          ]
         }
       ]
     },
@@ -562,6 +627,36 @@
               "comment": "Type name [mvp]",
               "name": "entity.name.type.wat",
               "match": "\\b(?:i32|i64|f32|f64)\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "GC Types",
+          "patterns": [
+            {
+              "comment": "Type name [GC]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:i8|i16|funcref|externref|anyref|eqref|i31ref|nullfuncref|nullexternref|structref|arrayref|nullref)\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "GC Heap Types",
+          "patterns": [
+            {
+              "comment": "Type name [GC]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:type|func|extern|any|eq|nofunc|noextern|struct|array|none)\\b(?!\\.)"
+            }
+          ]
+        },
+        {
+          "comment": "GC Structured and sub Types",
+          "patterns": [
+            {
+              "comment": "Type name [GC]",
+              "name": "entity.name.type.wat",
+              "match": "\\b(?:struct|array|sub|final|rec|field|mut)\\b(?!\\.)"
             }
           ]
         }


### PR DESCRIPTION
Add instructions and types from https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md

Instructions Covered:
 - [x] Reference Instructions
 - [x] Struct Instructions
 - [x] Array Instructions
 - [x] i31 Instructions
 - [x] Branch Instructions
 - [x] Reference Instructions

Types Covered:
 - [x] Funcref proposal
 - [x] GC proposal
 - [x] Reftype proposal
 - [x] shorthand types
 
Added all these types to `wat` syntax 