### PR TITLE
add nested block comments

### DIFF
--- a/syntaxes/wat.json
+++ b/syntaxes/wat.json
@@ -38,20 +38,44 @@
           }
         },
         {
-          "comment": "Block comment",
-          "name": "comment.block.wat",
-          "begin": "\\(;",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.wat"
-            }
-          },
-          "end": ";\\)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.wat"
-            }
-          }
+          "include": "#blockcomment"
+        }
+      ]
+    },
+    "blockcomment": {
+      "comment": "Block comment",
+      "name": "comment.block.wat",
+      "begin": "\\(;",
+      "end": ";\\)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.wat"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.wat"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#blockchar"
+        }
+      ]
+    },
+    "blockchar": {
+      "patterns": [
+        {
+          "match": "[^;(]"
+        },
+        {
+          "match": ";(?!\\))"
+        },
+        {
+          "match": "\\((?!;)"
+        },
+        {
+          "include": "#blockcomment"
         }
       ]
     },


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/7d67b3b0-e23c-4d3a-a5a4-8ef71777af89)

after:
![image](https://github.com/user-attachments/assets/fde5262e-1c9e-4f2a-94b0-650de989634b)

added rules are based on https://webassembly.github.io/spec/core/text/lexical.html#comments